### PR TITLE
Add OLM v1 ClusterExtension CRD schema for kubeconform

### DIFF
--- a/master-standalone-strict/clusterextension-olm-v1.json
+++ b/master-standalone-strict/clusterextension-olm-v1.json
@@ -1,0 +1,383 @@
+{
+  "description": "ClusterExtension is the Schema for the clusterextensions API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec is an optional field that defines the desired state of the ClusterExtension.",
+      "properties": {
+        "config": {
+          "description": "config is optional and specifies bundle-specific configuration.\nConfiguration is bundle-specific and a bundle may provide a configuration schema.\nWhen not specified, the default configuration of the resolved bundle is used.\n\nconfig is validated against a configuration schema provided by the resolved bundle. If the bundle does not provide\na configuration schema the bundle is deemed to not be configurable. More information on how\nto configure bundles can be found in the OLM documentation associated with your current OLM version.",
+          "properties": {
+            "configType": {
+              "description": "configType is required and specifies the type of configuration source.\n\nThe only allowed value is \"Inline\".\n\nWhen set to \"Inline\", the cluster extension configuration is defined inline within the ClusterExtension resource.",
+              "enum": [
+                "Inline"
+              ],
+              "type": "string"
+            },
+            "inline": {
+              "description": "inline contains JSON or YAML values specified directly in the ClusterExtension.\n\nIt is used to specify arbitrary configuration values for the ClusterExtension.\nIt must be set if configType is 'Inline' and must be a valid JSON/YAML object containing at least one property.\nThe configuration values are validated at runtime against a JSON schema provided by the bundle.",
+              "minProperties": 1,
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            }
+          },
+          "required": [
+            "configType"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "inline is required when configType is Inline, and forbidden otherwise",
+              "rule": "has(self.configType) && self.configType == 'Inline' ?has(self.inline) : !has(self.inline)"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "install": {
+          "description": "install is optional and configures installation options for the ClusterExtension,\nsuch as the pre-flight check configuration.",
+          "properties": {
+            "preflight": {
+              "description": "preflight is optional and configures the checks that run before installation or upgrade\nof the content for the package specified in the packageName field.\n\nWhen specified, it replaces the default preflight configuration for install/upgrade actions.\nWhen not specified, the default configuration is used.",
+              "properties": {
+                "crdUpgradeSafety": {
+                  "description": "crdUpgradeSafety configures the CRD Upgrade Safety pre-flight checks that run\nbefore upgrades of installed content.\n\nThe CRD Upgrade Safety pre-flight check safeguards from unintended consequences of upgrading a CRD,\nsuch as data loss.",
+                  "properties": {
+                    "enforcement": {
+                      "description": "enforcement is required and configures the state of the CRD Upgrade Safety pre-flight check.\n\nAllowed values are \"None\" or \"Strict\". The default value is \"Strict\".\n\nWhen set to \"None\", the CRD Upgrade Safety pre-flight check is skipped during an upgrade operation.\nUse this option with caution as unintended consequences such as data loss can occur.\n\nWhen set to \"Strict\", the CRD Upgrade Safety pre-flight check runs during an upgrade operation.",
+                      "enum": [
+                        "None",
+                        "Strict"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enforcement"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "crdUpgradeSafety"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of [crdUpgradeSafety] are required when preflight is specified",
+                  "rule": "has(self.crdUpgradeSafety)"
+                }
+              ],
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "at least one of [preflight] are required when install is specified",
+              "rule": "has(self.preflight)"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "namespace": {
+          "description": "namespace specifies a Kubernetes namespace.\nThis is the namespace where the provided ServiceAccount must exist.\nIt also designates the default namespace where namespace-scoped resources for the extension are applied to the cluster.\nSome extensions may contain namespace-scoped resources to be applied in other namespaces.\nThis namespace must exist.\n\nThe namespace field is required, immutable, and follows the DNS label standard as defined in [RFC 1123].\nIt must contain only lowercase alphanumeric characters or hyphens (-), start and end with an alphanumeric character,\nand be no longer than 63 characters.\n\n[RFC 1123]: https://tools.ietf.org/html/rfc1123",
+          "maxLength": 63,
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "namespace is immutable",
+              "rule": "self == oldSelf"
+            },
+            {
+              "message": "namespace must be a valid DNS1123 label",
+              "rule": "self.matches(\"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$\")"
+            }
+          ]
+        },
+        "serviceAccount": {
+          "description": "serviceAccount specifies a ServiceAccount used to perform all interactions with the cluster\nthat are required to manage the extension.\nThe ServiceAccount must be configured with the necessary permissions to perform these interactions.\nThe ServiceAccount must exist in the namespace referenced in the spec.\nThe serviceAccount field is required.",
+          "properties": {
+            "name": {
+              "description": "name is a required, immutable reference to the name of the ServiceAccount used for installation\nand management of the content for the package specified in the packageName field.\n\nThis ServiceAccount must exist in the installNamespace.\n\nThe name field follows the DNS subdomain standard as defined in [RFC 1123].\nIt must contain only lowercase alphanumeric characters, hyphens (-) or periods (.),\nstart and end with an alphanumeric character, and be no longer than 253 characters.\n\nSome examples of valid values are:\n  - some-serviceaccount\n  - 123-serviceaccount\n  - 1-serviceaccount-2\n  - someserviceaccount\n  - some.serviceaccount\n\nSome examples of invalid values are:\n  - -some-serviceaccount\n  - some-serviceaccount-\n\n[RFC 1123]: https://tools.ietf.org/html/rfc1123",
+              "maxLength": 253,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "name is immutable",
+                  "rule": "self == oldSelf"
+                },
+                {
+                  "message": "name must be a valid DNS1123 subdomain. It must contain only lowercase alphanumeric characters, hyphens (-) or periods (.), start and end with an alphanumeric character, and be no longer than 253 characters",
+                  "rule": "self.matches(\"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$\")"
+                }
+              ]
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "source": {
+          "description": "source is required and selects the installation source of content for this ClusterExtension.\nSet the sourceType field to perform the selection.\n\nCatalog is currently the only implemented sourceType.\nSetting sourceType to \"Catalog\" requires the catalog field to also be defined.\n\nBelow is a minimal example of a source definition (in yaml):\n\nsource:\n  sourceType: Catalog\n  catalog:\n    packageName: example-package",
+          "properties": {
+            "catalog": {
+              "description": "catalog configures how information is sourced from a catalog.\nIt is required when sourceType is \"Catalog\", and forbidden otherwise.",
+              "properties": {
+                "channels": {
+                  "description": "channels is optional and specifies a set of channels belonging to the package\nspecified in the packageName field.\n\nA channel is a package-author-defined stream of updates for an extension.\n\nEach channel in the list must follow the DNS subdomain standard as defined in [RFC 1123].\nIt must contain only lowercase alphanumeric characters, hyphens (-) or periods (.),\nstart and end with an alphanumeric character, and be no longer than 253 characters.\nYou can specify no more than 256 channels.\n\nWhen specified, it constrains the set of installable bundles and the automated upgrade path.\nThis constraint is an AND operation with the version field. For example:\n  - Given channel is set to \"foo\"\n  - Given version is set to \">=1.0.0, <1.5.0\"\n  - Only bundles that exist in channel \"foo\" AND satisfy the version range comparison are considered installable\n  - Automatic upgrades are constrained to upgrade edges defined by the selected channel\n\nWhen unspecified, upgrade edges across all channels are used to identify valid automatic upgrade paths.\n\nSome examples of valid values are:\n  - 1.1.x\n  - alpha\n  - stable\n  - stable-v1\n  - v1-stable\n  - dev-preview\n  - preview\n  - community\n\nSome examples of invalid values are:\n  - -some-channel\n  - some-channel-\n  - thisisareallylongchannelnamethatisgreaterthanthemaximumlength\n  - original_40\n  - --default-channel\n\n[RFC 1123]: https://tools.ietf.org/html/rfc1123",
+                  "items": {
+                    "maxLength": 253,
+                    "type": "string",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "channels entries must be valid DNS1123 subdomains",
+                        "rule": "self.matches(\"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$\")"
+                      }
+                    ]
+                  },
+                  "maxItems": 256,
+                  "type": "array"
+                },
+                "packageName": {
+                  "description": "packageName specifies the name of the package to be installed and is used to filter\nthe content from catalogs.\n\nIt is required, immutable, and follows the DNS subdomain standard as defined in [RFC 1123].\nIt must contain only lowercase alphanumeric characters, hyphens (-) or periods (.),\nstart and end with an alphanumeric character, and be no longer than 253 characters.\n\nSome examples of valid values are:\n  - some-package\n  - 123-package\n  - 1-package-2\n  - somepackage\n\nSome examples of invalid values are:\n  - -some-package\n  - some-package-\n  - thisisareallylongpackagenamethatisgreaterthanthemaximumlength\n  - some.package\n\n[RFC 1123]: https://tools.ietf.org/html/rfc1123",
+                  "maxLength": 253,
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "packageName is immutable",
+                      "rule": "self == oldSelf"
+                    },
+                    {
+                      "message": "packageName must be a valid DNS1123 subdomain. It must contain only lowercase alphanumeric characters, hyphens (-) or periods (.), start and end with an alphanumeric character, and be no longer than 253 characters",
+                      "rule": "self.matches(\"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$\")"
+                    }
+                  ]
+                },
+                "selector": {
+                  "description": "selector is optional and filters the set of ClusterCatalogs used in the bundle selection process.\n\nWhen unspecified, all ClusterCatalogs are used in the bundle selection process.",
+                  "properties": {
+                    "matchExpressions": {
+                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                      "items": {
+                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                        "properties": {
+                          "key": {
+                            "description": "key is the label key that the selector applies to.",
+                            "type": "string"
+                          },
+                          "operator": {
+                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "matchLabels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "upgradeConstraintPolicy": {
+                  "default": "CatalogProvided",
+                  "description": "upgradeConstraintPolicy is optional and controls whether the upgrade paths defined in the catalog\nare enforced for the package referenced in the packageName field.\n\nAllowed values are \"CatalogProvided\", \"SelfCertified\", or omitted.\n\nWhen set to \"CatalogProvided\", automatic upgrades only occur when upgrade constraints specified by the package\nauthor are met.\n\nWhen set to \"SelfCertified\", the upgrade constraints specified by the package author are ignored.\nThis allows upgrades and downgrades to any version of the package.\nThis is considered a dangerous operation as it can lead to unknown and potentially disastrous outcomes,\nsuch as data loss.\nUse this option only if you have independently verified the changes.\n\nWhen omitted, the default value is \"CatalogProvided\".",
+                  "enum": [
+                    "CatalogProvided",
+                    "SelfCertified"
+                  ],
+                  "type": "string"
+                },
+                "version": {
+                  "description": "version is an optional semver constraint (a specific version or range of versions).\nWhen unspecified, the latest version available is installed.\n\nAcceptable version ranges are no longer than 64 characters.\nVersion ranges are composed of comma- or space-delimited values and one or more comparison operators,\nknown as comparison strings.\nYou can add additional comparison strings using the OR operator (||).\n\n# Range Comparisons\n\nTo specify a version range, you can use a comparison string like \">=3.0,\n<3.6\". When specifying a range, automatic updates will occur within that\nrange. The example comparison string means \"install any version greater than\nor equal to 3.0.0 but less than 3.6.0.\". It also states intent that if any\nupgrades are available within the version range after initial installation,\nthose upgrades should be automatically performed.\n\n# Pinned Versions\n\nTo specify an exact version to install you can use a version range that\n\"pins\" to a specific version. When pinning to a specific version, no\nautomatic updates will occur. An example of a pinned version range is\n\"0.6.0\", which means \"only install version 0.6.0 and never\nupgrade from this version\".\n\n# Basic Comparison Operators\n\nThe basic comparison operators and their meanings are:\n  - \"=\", equal (not aliased to an operator)\n  - \"!=\", not equal\n  - \"<\", less than\n  - \">\", greater than\n  - \">=\", greater than OR equal to\n  - \"<=\", less than OR equal to\n\n# Wildcard Comparisons\n\nYou can use the \"x\", \"X\", and \"*\" characters as wildcard characters in all\ncomparison operations. Some examples of using the wildcard characters:\n  - \"1.2.x\", \"1.2.X\", and \"1.2.*\" is equivalent to \">=1.2.0, < 1.3.0\"\n  - \">= 1.2.x\", \">= 1.2.X\", and \">= 1.2.*\" is equivalent to \">= 1.2.0\"\n  - \"<= 2.x\", \"<= 2.X\", and \"<= 2.*\" is equivalent to \"< 3\"\n  - \"x\", \"X\", and \"*\" is equivalent to \">= 0.0.0\"\n\n# Patch Release Comparisons\n\nWhen you want to specify a minor version up to the next major version you\ncan use the \"~\" character to perform patch comparisons. Some examples:\n  - \"~1.2.3\" is equivalent to \">=1.2.3, <1.3.0\"\n  - \"~1\" and \"~1.x\" is equivalent to \">=1, <2\"\n  - \"~2.3\" is equivalent to \">=2.3, <2.4\"\n  - \"~1.2.x\" is equivalent to \">=1.2.0, <1.3.0\"\n\n# Major Release Comparisons\n\nYou can use the \"^\" character to make major release comparisons after a\nstable 1.0.0 version is published. If there is no stable version published, // minor versions define the stability level. Some examples:\n  - \"^1.2.3\" is equivalent to \">=1.2.3, <2.0.0\"\n  - \"^1.2.x\" is equivalent to \">=1.2.0, <2.0.0\"\n  - \"^2.3\" is equivalent to \">=2.3, <3\"\n  - \"^2.x\" is equivalent to \">=2.0.0, <3\"\n  - \"^0.2.3\" is equivalent to \">=0.2.3, <0.3.0\"\n  - \"^0.2\" is equivalent to \">=0.2.0, <0.3.0\"\n  - \"^0.0.3\" is equvalent to \">=0.0.3, <0.0.4\"\n  - \"^0.0\" is equivalent to \">=0.0.0, <0.1.0\"\n  - \"^0\" is equivalent to \">=0.0.0, <1.0.0\"\n\n# OR Comparisons\nYou can use the \"||\" character to represent an OR operation in the version\nrange. Some examples:\n  - \">=1.2.3, <2.0.0 || >3.0.0\"\n  - \"^0 || ^3 || ^5\"\n\nFor more information on semver, please see https://semver.org/",
+                  "maxLength": 64,
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid version expression",
+                      "rule": "self.matches(\"^(\\\\s*(=||!=|>|<|>=|=>|<=|=<|~|~>|\\\\^)\\\\s*(v?(0|[1-9]\\\\d*|[x|X|\\\\*])(\\\\.(0|[1-9]\\\\d*|x|X|\\\\*]))?(\\\\.(0|[1-9]\\\\d*|x|X|\\\\*))?(-([0-9A-Za-z\\\\-]+(\\\\.[0-9A-Za-z\\\\-]+)*))?(\\\\+([0-9A-Za-z\\\\-]+(\\\\.[0-9A-Za-z\\\\-]+)*))?)\\\\s*)((?:\\\\s+|,\\\\s*|\\\\s*\\\\|\\\\|\\\\s*)(=||!=|>|<|>=|=>|<=|=<|~|~>|\\\\^)\\\\s*(v?(0|[1-9]\\\\d*|x|X|\\\\*])(\\\\.(0|[1-9]\\\\d*|x|X|\\\\*))?(\\\\.(0|[1-9]\\\\d*|x|X|\\\\*]))?(-([0-9A-Za-z\\\\-]+(\\\\.[0-9A-Za-z\\\\-]+)*))?(\\\\+([0-9A-Za-z\\\\-]+(\\\\.[0-9A-Za-z\\\\-]+)*))?)\\\\s*)*$\")"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "packageName"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sourceType": {
+              "description": "sourceType is required and specifies the type of install source.\n\nThe only allowed value is \"Catalog\".\n\nWhen set to \"Catalog\", information for determining the appropriate bundle of content to install\nis fetched from ClusterCatalog resources on the cluster.\nWhen using the Catalog sourceType, the catalog field must also be set.",
+              "enum": [
+                "Catalog"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "sourceType"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "catalog is required when sourceType is Catalog, and forbidden otherwise",
+              "rule": "has(self.sourceType) && self.sourceType == 'Catalog' ? has(self.catalog) : !has(self.catalog)"
+            }
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "namespace",
+        "serviceAccount",
+        "source"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "status is an optional field that defines the observed state of the ClusterExtension.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the current state of the ClusterExtension.\n\nThe set of condition types which apply to all spec.source variations are Installed and Progressing.\n\nThe Installed condition represents whether the bundle has been installed for this ClusterExtension:\n  - When Installed is True and the Reason is Succeeded, the bundle has been successfully installed.\n  - When Installed is False and the Reason is Failed, the bundle has failed to install.\n\nThe Progressing condition represents whether or not the ClusterExtension is advancing towards a new state.\nWhen Progressing is True and the Reason is Succeeded, the ClusterExtension is making progress towards a new state.\nWhen Progressing is True and the Reason is Retrying, the ClusterExtension has encountered an error that could be resolved on subsequent reconciliation attempts.\nWhen Progressing is False and the Reason is Blocked, the ClusterExtension has encountered an error that requires manual intervention for recovery.\n\nWhen the ClusterExtension is sourced from a catalog, it surfaces deprecation conditions based on catalog metadata.\nThese are indications from a package owner to guide users away from a particular package, channel, or bundle:\n  - BundleDeprecated is True if the installed bundle is marked deprecated, False if not deprecated, or Unknown if no bundle is installed yet or if catalog data is unavailable.\n  - ChannelDeprecated is True if any requested channel is marked deprecated, False if not deprecated, or Unknown if catalog data is unavailable.\n  - PackageDeprecated is True if the requested package is marked deprecated, False if not deprecated, or Unknown if catalog data is unavailable.\n  - Deprecated is a rollup condition that is True when any deprecation exists, False when none exist, or Unknown when catalog data is unavailable.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "install": {
+          "description": "install is a representation of the current installation status for this ClusterExtension.",
+          "properties": {
+            "bundle": {
+              "description": "bundle is required and represents the identifying attributes of a bundle.\n\nA \"bundle\" is a versioned set of content that represents the resources that need to be applied\nto a cluster to install a package.",
+              "properties": {
+                "name": {
+                  "description": "name is required and follows the DNS subdomain standard as defined in [RFC 1123].\nIt must contain only lowercase alphanumeric characters, hyphens (-) or periods (.),\nstart and end with an alphanumeric character, and be no longer than 253 characters.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "packageName must be a valid DNS1123 subdomain. It must contain only lowercase alphanumeric characters, hyphens (-) or periods (.), start and end with an alphanumeric character, and be no longer than 253 characters",
+                      "rule": "self.matches(\"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$\")"
+                    }
+                  ]
+                },
+                "version": {
+                  "description": "version is required and references the version that this bundle represents.\nIt follows the semantic versioning standard as defined in https://semver.org/.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "version must be well-formed semver",
+                      "rule": "self.matches(\"^([0-9]+)(\\\\.[0-9]+)?(\\\\.[0-9]+)?(-([-0-9A-Za-z]+(\\\\.[-0-9A-Za-z]+)*))?(\\\\+([-0-9A-Za-z]+(-\\\\.[-0-9A-Za-z]+)*))?\")"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "name",
+                "version"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "bundle"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/master-standalone/clusterextension-olm-v1.json
+++ b/master-standalone/clusterextension-olm-v1.json
@@ -1,0 +1,383 @@
+{
+  "description": "ClusterExtension is the Schema for the clusterextensions API",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "spec is an optional field that defines the desired state of the ClusterExtension.",
+      "properties": {
+        "config": {
+          "description": "config is optional and specifies bundle-specific configuration.\nConfiguration is bundle-specific and a bundle may provide a configuration schema.\nWhen not specified, the default configuration of the resolved bundle is used.\n\nconfig is validated against a configuration schema provided by the resolved bundle. If the bundle does not provide\na configuration schema the bundle is deemed to not be configurable. More information on how\nto configure bundles can be found in the OLM documentation associated with your current OLM version.",
+          "properties": {
+            "configType": {
+              "description": "configType is required and specifies the type of configuration source.\n\nThe only allowed value is \"Inline\".\n\nWhen set to \"Inline\", the cluster extension configuration is defined inline within the ClusterExtension resource.",
+              "enum": [
+                "Inline"
+              ],
+              "type": "string"
+            },
+            "inline": {
+              "description": "inline contains JSON or YAML values specified directly in the ClusterExtension.\n\nIt is used to specify arbitrary configuration values for the ClusterExtension.\nIt must be set if configType is 'Inline' and must be a valid JSON/YAML object containing at least one property.\nThe configuration values are validated at runtime against a JSON schema provided by the bundle.",
+              "minProperties": 1,
+              "type": "object",
+              "x-kubernetes-preserve-unknown-fields": true
+            }
+          },
+          "required": [
+            "configType"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "inline is required when configType is Inline, and forbidden otherwise",
+              "rule": "has(self.configType) && self.configType == 'Inline' ?has(self.inline) : !has(self.inline)"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "install": {
+          "description": "install is optional and configures installation options for the ClusterExtension,\nsuch as the pre-flight check configuration.",
+          "properties": {
+            "preflight": {
+              "description": "preflight is optional and configures the checks that run before installation or upgrade\nof the content for the package specified in the packageName field.\n\nWhen specified, it replaces the default preflight configuration for install/upgrade actions.\nWhen not specified, the default configuration is used.",
+              "properties": {
+                "crdUpgradeSafety": {
+                  "description": "crdUpgradeSafety configures the CRD Upgrade Safety pre-flight checks that run\nbefore upgrades of installed content.\n\nThe CRD Upgrade Safety pre-flight check safeguards from unintended consequences of upgrading a CRD,\nsuch as data loss.",
+                  "properties": {
+                    "enforcement": {
+                      "description": "enforcement is required and configures the state of the CRD Upgrade Safety pre-flight check.\n\nAllowed values are \"None\" or \"Strict\". The default value is \"Strict\".\n\nWhen set to \"None\", the CRD Upgrade Safety pre-flight check is skipped during an upgrade operation.\nUse this option with caution as unintended consequences such as data loss can occur.\n\nWhen set to \"Strict\", the CRD Upgrade Safety pre-flight check runs during an upgrade operation.",
+                      "enum": [
+                        "None",
+                        "Strict"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "enforcement"
+                  ],
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "required": [
+                "crdUpgradeSafety"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "at least one of [crdUpgradeSafety] are required when preflight is specified",
+                  "rule": "has(self.crdUpgradeSafety)"
+                }
+              ],
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "at least one of [preflight] are required when install is specified",
+              "rule": "has(self.preflight)"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "namespace": {
+          "description": "namespace specifies a Kubernetes namespace.\nThis is the namespace where the provided ServiceAccount must exist.\nIt also designates the default namespace where namespace-scoped resources for the extension are applied to the cluster.\nSome extensions may contain namespace-scoped resources to be applied in other namespaces.\nThis namespace must exist.\n\nThe namespace field is required, immutable, and follows the DNS label standard as defined in [RFC 1123].\nIt must contain only lowercase alphanumeric characters or hyphens (-), start and end with an alphanumeric character,\nand be no longer than 63 characters.\n\n[RFC 1123]: https://tools.ietf.org/html/rfc1123",
+          "maxLength": 63,
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "namespace is immutable",
+              "rule": "self == oldSelf"
+            },
+            {
+              "message": "namespace must be a valid DNS1123 label",
+              "rule": "self.matches(\"^[a-z0-9]([-a-z0-9]*[a-z0-9])?$\")"
+            }
+          ]
+        },
+        "serviceAccount": {
+          "description": "serviceAccount specifies a ServiceAccount used to perform all interactions with the cluster\nthat are required to manage the extension.\nThe ServiceAccount must be configured with the necessary permissions to perform these interactions.\nThe ServiceAccount must exist in the namespace referenced in the spec.\nThe serviceAccount field is required.",
+          "properties": {
+            "name": {
+              "description": "name is a required, immutable reference to the name of the ServiceAccount used for installation\nand management of the content for the package specified in the packageName field.\n\nThis ServiceAccount must exist in the installNamespace.\n\nThe name field follows the DNS subdomain standard as defined in [RFC 1123].\nIt must contain only lowercase alphanumeric characters, hyphens (-) or periods (.),\nstart and end with an alphanumeric character, and be no longer than 253 characters.\n\nSome examples of valid values are:\n  - some-serviceaccount\n  - 123-serviceaccount\n  - 1-serviceaccount-2\n  - someserviceaccount\n  - some.serviceaccount\n\nSome examples of invalid values are:\n  - -some-serviceaccount\n  - some-serviceaccount-\n\n[RFC 1123]: https://tools.ietf.org/html/rfc1123",
+              "maxLength": 253,
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "name is immutable",
+                  "rule": "self == oldSelf"
+                },
+                {
+                  "message": "name must be a valid DNS1123 subdomain. It must contain only lowercase alphanumeric characters, hyphens (-) or periods (.), start and end with an alphanumeric character, and be no longer than 253 characters",
+                  "rule": "self.matches(\"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$\")"
+                }
+              ]
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "source": {
+          "description": "source is required and selects the installation source of content for this ClusterExtension.\nSet the sourceType field to perform the selection.\n\nCatalog is currently the only implemented sourceType.\nSetting sourceType to \"Catalog\" requires the catalog field to also be defined.\n\nBelow is a minimal example of a source definition (in yaml):\n\nsource:\n  sourceType: Catalog\n  catalog:\n    packageName: example-package",
+          "properties": {
+            "catalog": {
+              "description": "catalog configures how information is sourced from a catalog.\nIt is required when sourceType is \"Catalog\", and forbidden otherwise.",
+              "properties": {
+                "channels": {
+                  "description": "channels is optional and specifies a set of channels belonging to the package\nspecified in the packageName field.\n\nA channel is a package-author-defined stream of updates for an extension.\n\nEach channel in the list must follow the DNS subdomain standard as defined in [RFC 1123].\nIt must contain only lowercase alphanumeric characters, hyphens (-) or periods (.),\nstart and end with an alphanumeric character, and be no longer than 253 characters.\nYou can specify no more than 256 channels.\n\nWhen specified, it constrains the set of installable bundles and the automated upgrade path.\nThis constraint is an AND operation with the version field. For example:\n  - Given channel is set to \"foo\"\n  - Given version is set to \">=1.0.0, <1.5.0\"\n  - Only bundles that exist in channel \"foo\" AND satisfy the version range comparison are considered installable\n  - Automatic upgrades are constrained to upgrade edges defined by the selected channel\n\nWhen unspecified, upgrade edges across all channels are used to identify valid automatic upgrade paths.\n\nSome examples of valid values are:\n  - 1.1.x\n  - alpha\n  - stable\n  - stable-v1\n  - v1-stable\n  - dev-preview\n  - preview\n  - community\n\nSome examples of invalid values are:\n  - -some-channel\n  - some-channel-\n  - thisisareallylongchannelnamethatisgreaterthanthemaximumlength\n  - original_40\n  - --default-channel\n\n[RFC 1123]: https://tools.ietf.org/html/rfc1123",
+                  "items": {
+                    "maxLength": 253,
+                    "type": "string",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "channels entries must be valid DNS1123 subdomains",
+                        "rule": "self.matches(\"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$\")"
+                      }
+                    ]
+                  },
+                  "maxItems": 256,
+                  "type": "array"
+                },
+                "packageName": {
+                  "description": "packageName specifies the name of the package to be installed and is used to filter\nthe content from catalogs.\n\nIt is required, immutable, and follows the DNS subdomain standard as defined in [RFC 1123].\nIt must contain only lowercase alphanumeric characters, hyphens (-) or periods (.),\nstart and end with an alphanumeric character, and be no longer than 253 characters.\n\nSome examples of valid values are:\n  - some-package\n  - 123-package\n  - 1-package-2\n  - somepackage\n\nSome examples of invalid values are:\n  - -some-package\n  - some-package-\n  - thisisareallylongpackagenamethatisgreaterthanthemaximumlength\n  - some.package\n\n[RFC 1123]: https://tools.ietf.org/html/rfc1123",
+                  "maxLength": 253,
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "packageName is immutable",
+                      "rule": "self == oldSelf"
+                    },
+                    {
+                      "message": "packageName must be a valid DNS1123 subdomain. It must contain only lowercase alphanumeric characters, hyphens (-) or periods (.), start and end with an alphanumeric character, and be no longer than 253 characters",
+                      "rule": "self.matches(\"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$\")"
+                    }
+                  ]
+                },
+                "selector": {
+                  "description": "selector is optional and filters the set of ClusterCatalogs used in the bundle selection process.\n\nWhen unspecified, all ClusterCatalogs are used in the bundle selection process.",
+                  "properties": {
+                    "matchExpressions": {
+                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                      "items": {
+                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                        "properties": {
+                          "key": {
+                            "description": "key is the label key that the selector applies to.",
+                            "type": "string"
+                          },
+                          "operator": {
+                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array",
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        },
+                        "required": [
+                          "key",
+                          "operator"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array",
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "matchLabels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "x-kubernetes-map-type": "atomic",
+                  "additionalProperties": false
+                },
+                "upgradeConstraintPolicy": {
+                  "default": "CatalogProvided",
+                  "description": "upgradeConstraintPolicy is optional and controls whether the upgrade paths defined in the catalog\nare enforced for the package referenced in the packageName field.\n\nAllowed values are \"CatalogProvided\", \"SelfCertified\", or omitted.\n\nWhen set to \"CatalogProvided\", automatic upgrades only occur when upgrade constraints specified by the package\nauthor are met.\n\nWhen set to \"SelfCertified\", the upgrade constraints specified by the package author are ignored.\nThis allows upgrades and downgrades to any version of the package.\nThis is considered a dangerous operation as it can lead to unknown and potentially disastrous outcomes,\nsuch as data loss.\nUse this option only if you have independently verified the changes.\n\nWhen omitted, the default value is \"CatalogProvided\".",
+                  "enum": [
+                    "CatalogProvided",
+                    "SelfCertified"
+                  ],
+                  "type": "string"
+                },
+                "version": {
+                  "description": "version is an optional semver constraint (a specific version or range of versions).\nWhen unspecified, the latest version available is installed.\n\nAcceptable version ranges are no longer than 64 characters.\nVersion ranges are composed of comma- or space-delimited values and one or more comparison operators,\nknown as comparison strings.\nYou can add additional comparison strings using the OR operator (||).\n\n# Range Comparisons\n\nTo specify a version range, you can use a comparison string like \">=3.0,\n<3.6\". When specifying a range, automatic updates will occur within that\nrange. The example comparison string means \"install any version greater than\nor equal to 3.0.0 but less than 3.6.0.\". It also states intent that if any\nupgrades are available within the version range after initial installation,\nthose upgrades should be automatically performed.\n\n# Pinned Versions\n\nTo specify an exact version to install you can use a version range that\n\"pins\" to a specific version. When pinning to a specific version, no\nautomatic updates will occur. An example of a pinned version range is\n\"0.6.0\", which means \"only install version 0.6.0 and never\nupgrade from this version\".\n\n# Basic Comparison Operators\n\nThe basic comparison operators and their meanings are:\n  - \"=\", equal (not aliased to an operator)\n  - \"!=\", not equal\n  - \"<\", less than\n  - \">\", greater than\n  - \">=\", greater than OR equal to\n  - \"<=\", less than OR equal to\n\n# Wildcard Comparisons\n\nYou can use the \"x\", \"X\", and \"*\" characters as wildcard characters in all\ncomparison operations. Some examples of using the wildcard characters:\n  - \"1.2.x\", \"1.2.X\", and \"1.2.*\" is equivalent to \">=1.2.0, < 1.3.0\"\n  - \">= 1.2.x\", \">= 1.2.X\", and \">= 1.2.*\" is equivalent to \">= 1.2.0\"\n  - \"<= 2.x\", \"<= 2.X\", and \"<= 2.*\" is equivalent to \"< 3\"\n  - \"x\", \"X\", and \"*\" is equivalent to \">= 0.0.0\"\n\n# Patch Release Comparisons\n\nWhen you want to specify a minor version up to the next major version you\ncan use the \"~\" character to perform patch comparisons. Some examples:\n  - \"~1.2.3\" is equivalent to \">=1.2.3, <1.3.0\"\n  - \"~1\" and \"~1.x\" is equivalent to \">=1, <2\"\n  - \"~2.3\" is equivalent to \">=2.3, <2.4\"\n  - \"~1.2.x\" is equivalent to \">=1.2.0, <1.3.0\"\n\n# Major Release Comparisons\n\nYou can use the \"^\" character to make major release comparisons after a\nstable 1.0.0 version is published. If there is no stable version published, // minor versions define the stability level. Some examples:\n  - \"^1.2.3\" is equivalent to \">=1.2.3, <2.0.0\"\n  - \"^1.2.x\" is equivalent to \">=1.2.0, <2.0.0\"\n  - \"^2.3\" is equivalent to \">=2.3, <3\"\n  - \"^2.x\" is equivalent to \">=2.0.0, <3\"\n  - \"^0.2.3\" is equivalent to \">=0.2.3, <0.3.0\"\n  - \"^0.2\" is equivalent to \">=0.2.0, <0.3.0\"\n  - \"^0.0.3\" is equvalent to \">=0.0.3, <0.0.4\"\n  - \"^0.0\" is equivalent to \">=0.0.0, <0.1.0\"\n  - \"^0\" is equivalent to \">=0.0.0, <1.0.0\"\n\n# OR Comparisons\nYou can use the \"||\" character to represent an OR operation in the version\nrange. Some examples:\n  - \">=1.2.3, <2.0.0 || >3.0.0\"\n  - \"^0 || ^3 || ^5\"\n\nFor more information on semver, please see https://semver.org/",
+                  "maxLength": 64,
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "invalid version expression",
+                      "rule": "self.matches(\"^(\\\\s*(=||!=|>|<|>=|=>|<=|=<|~|~>|\\\\^)\\\\s*(v?(0|[1-9]\\\\d*|[x|X|\\\\*])(\\\\.(0|[1-9]\\\\d*|x|X|\\\\*]))?(\\\\.(0|[1-9]\\\\d*|x|X|\\\\*))?(-([0-9A-Za-z\\\\-]+(\\\\.[0-9A-Za-z\\\\-]+)*))?(\\\\+([0-9A-Za-z\\\\-]+(\\\\.[0-9A-Za-z\\\\-]+)*))?)\\\\s*)((?:\\\\s+|,\\\\s*|\\\\s*\\\\|\\\\|\\\\s*)(=||!=|>|<|>=|=>|<=|=<|~|~>|\\\\^)\\\\s*(v?(0|[1-9]\\\\d*|x|X|\\\\*])(\\\\.(0|[1-9]\\\\d*|x|X|\\\\*))?(\\\\.(0|[1-9]\\\\d*|x|X|\\\\*]))?(-([0-9A-Za-z\\\\-]+(\\\\.[0-9A-Za-z\\\\-]+)*))?(\\\\+([0-9A-Za-z\\\\-]+(\\\\.[0-9A-Za-z\\\\-]+)*))?)\\\\s*)*$\")"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "packageName"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            },
+            "sourceType": {
+              "description": "sourceType is required and specifies the type of install source.\n\nThe only allowed value is \"Catalog\".\n\nWhen set to \"Catalog\", information for determining the appropriate bundle of content to install\nis fetched from ClusterCatalog resources on the cluster.\nWhen using the Catalog sourceType, the catalog field must also be set.",
+              "enum": [
+                "Catalog"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "sourceType"
+          ],
+          "type": "object",
+          "x-kubernetes-validations": [
+            {
+              "message": "catalog is required when sourceType is Catalog, and forbidden otherwise",
+              "rule": "has(self.sourceType) && self.sourceType == 'Catalog' ? has(self.catalog) : !has(self.catalog)"
+            }
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "namespace",
+        "serviceAccount",
+        "source"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "status is an optional field that defines the observed state of the ClusterExtension.",
+      "properties": {
+        "conditions": {
+          "description": "conditions represents the current state of the ClusterExtension.\n\nThe set of condition types which apply to all spec.source variations are Installed and Progressing.\n\nThe Installed condition represents whether the bundle has been installed for this ClusterExtension:\n  - When Installed is True and the Reason is Succeeded, the bundle has been successfully installed.\n  - When Installed is False and the Reason is Failed, the bundle has failed to install.\n\nThe Progressing condition represents whether or not the ClusterExtension is advancing towards a new state.\nWhen Progressing is True and the Reason is Succeeded, the ClusterExtension is making progress towards a new state.\nWhen Progressing is True and the Reason is Retrying, the ClusterExtension has encountered an error that could be resolved on subsequent reconciliation attempts.\nWhen Progressing is False and the Reason is Blocked, the ClusterExtension has encountered an error that requires manual intervention for recovery.\n\nWhen the ClusterExtension is sourced from a catalog, it surfaces deprecation conditions based on catalog metadata.\nThese are indications from a package owner to guide users away from a particular package, channel, or bundle:\n  - BundleDeprecated is True if the installed bundle is marked deprecated, False if not deprecated, or Unknown if no bundle is installed yet or if catalog data is unavailable.\n  - ChannelDeprecated is True if any requested channel is marked deprecated, False if not deprecated, or Unknown if catalog data is unavailable.\n  - PackageDeprecated is True if the requested package is marked deprecated, False if not deprecated, or Unknown if catalog data is unavailable.\n  - Deprecated is a rollup condition that is True when any deprecation exists, False when none exist, or Unknown when catalog data is unavailable.",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "maxLength": 32768,
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$",
+                "type": "string"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ],
+                "type": "string"
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "install": {
+          "description": "install is a representation of the current installation status for this ClusterExtension.",
+          "properties": {
+            "bundle": {
+              "description": "bundle is required and represents the identifying attributes of a bundle.\n\nA \"bundle\" is a versioned set of content that represents the resources that need to be applied\nto a cluster to install a package.",
+              "properties": {
+                "name": {
+                  "description": "name is required and follows the DNS subdomain standard as defined in [RFC 1123].\nIt must contain only lowercase alphanumeric characters, hyphens (-) or periods (.),\nstart and end with an alphanumeric character, and be no longer than 253 characters.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "packageName must be a valid DNS1123 subdomain. It must contain only lowercase alphanumeric characters, hyphens (-) or periods (.), start and end with an alphanumeric character, and be no longer than 253 characters",
+                      "rule": "self.matches(\"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$\")"
+                    }
+                  ]
+                },
+                "version": {
+                  "description": "version is required and references the version that this bundle represents.\nIt follows the semantic versioning standard as defined in https://semver.org/.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "version must be well-formed semver",
+                      "rule": "self.matches(\"^([0-9]+)(\\\\.[0-9]+)?(\\\\.[0-9]+)?(-([-0-9A-Za-z]+(\\\\.[-0-9A-Za-z]+)*))?(\\\\+([-0-9A-Za-z]+(-\\\\.[-0-9A-Za-z]+)*))?\")"
+                    }
+                  ]
+                }
+              },
+              "required": [
+                "name",
+                "version"
+              ],
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "bundle"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Source: operator-framework/operator-controller v1.8.0 (helm/olmv1/base/operator-controller/crd/standard/olm.operatorframework.io_clusterextensions.yaml)