### PR TITLE
SRE-12580: Update clickhouse CRDs

### DIFF
--- a/master-standalone-strict/clickhouseinstallation-clickhouse-v1.json
+++ b/master-standalone-strict/clickhouseinstallation-clickhouse-v1.json
@@ -1,16 +1,16 @@
 {
-  "description": "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters",
+  "description": "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more clusters",
   "type": "object",
   "required": [
     "spec"
   ],
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation\nof an object. Servers should convert recognized schemas to the latest\ninternal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources\n",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this\nobject represents. Servers may infer this from the endpoint the client\nsubmits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds\n",
       "type": "string"
     },
     "metadata": {
@@ -18,23 +18,23 @@
     },
     "status": {
       "type": "object",
-      "description": "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other",
+      "description": "Status contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other\n",
       "properties": {
         "chop-version": {
           "type": "string",
-          "description": "ClickHouse operator version"
+          "description": "Operator version"
         },
         "chop-commit": {
           "type": "string",
-          "description": "ClickHouse operator git commit SHA"
+          "description": "Operator git commit SHA"
         },
         "chop-date": {
           "type": "string",
-          "description": "ClickHouse operator build date"
+          "description": "Operator build date"
         },
         "chop-ip": {
           "type": "string",
-          "description": "IP address of the operator's pod which managed this CHI"
+          "description": "IP address of the operator's pod which managed this resource"
         },
         "clusters": {
           "type": "integer",
@@ -67,6 +67,7 @@
         "taskIDsStarted": {
           "type": "array",
           "description": "Started task ids",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -74,6 +75,7 @@
         "taskIDsCompleted": {
           "type": "array",
           "description": "Completed task ids",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -85,6 +87,7 @@
         "actions": {
           "type": "array",
           "description": "Actions",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -96,9 +99,15 @@
         "errors": {
           "type": "array",
           "description": "Errors",
+          "nullable": true,
           "items": {
             "type": "string"
           }
+        },
+        "hostsUnchanged": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Unchanged Hosts count"
         },
         "hostsUpdated": {
           "type": "integer",
@@ -128,6 +137,7 @@
         "pods": {
           "type": "array",
           "description": "Pods",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -135,6 +145,7 @@
         "pod-ips": {
           "type": "array",
           "description": "Pod IPs",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -142,6 +153,7 @@
         "fqdns": {
           "type": "array",
           "description": "Pods FQDNs",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -150,6 +162,14 @@
           "type": "string",
           "description": "Endpoint"
         },
+        "endpoints": {
+          "type": "array",
+          "description": "All endpoints",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
         "generation": {
           "type": "integer",
           "minimum": 0,
@@ -157,17 +177,34 @@
         },
         "normalized": {
           "type": "object",
-          "description": "Normalized CHI requested",
+          "description": "Normalized resource requested",
+          "nullable": true,
           "x-kubernetes-preserve-unknown-fields": true
         },
         "normalizedCompleted": {
           "type": "object",
-          "description": "Normalized CHI completed",
+          "description": "Normalized resource completed",
+          "nullable": true,
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "actionPlan": {
+          "type": "object",
+          "description": "Action Plan",
+          "nullable": true,
           "x-kubernetes-preserve-unknown-fields": true
         },
         "hostsWithTablesCreated": {
           "type": "array",
           "description": "List of hosts with tables created by the operator",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "hostsWithReplicaCaughtUp": {
+          "type": "array",
+          "description": "List of hosts with replica caught up",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -175,6 +212,7 @@
         "usedTemplates": {
           "type": "array",
           "description": "List of templates used to build this CHI",
+          "nullable": true,
           "x-kubernetes-preserve-unknown-fields": true,
           "items": {
             "type": "object",
@@ -229,6 +267,35 @@
             "RollingUpdate"
           ]
         },
+        "suspend": {
+          "type": "string",
+          "description": "Suspend reconciliation of resources managed by a ClickHouse Installation.\nWorks as the following:\n - When `suspend` is `true` operator stops reconciling all resources.\n - When `suspend` is `false` or not set, operator reconciles all resources.\n",
+          "enum": [
+            "",
+            "0",
+            "1",
+            "False",
+            "false",
+            "True",
+            "true",
+            "No",
+            "no",
+            "Yes",
+            "yes",
+            "Off",
+            "off",
+            "On",
+            "on",
+            "Disable",
+            "disable",
+            "Enable",
+            "enable",
+            "Disabled",
+            "disabled",
+            "Enabled",
+            "enabled"
+          ]
+        },
         "troubleshoot": {
           "type": "string",
           "description": "Allows to troubleshoot Pods during CrashLoopBack state.\nThis may happen when wrong configuration applied, in this case `clickhouse-server` wouldn't start.\nCommand within ClickHouse container is modified with `sleep` in order to avoid quick restarts\nand give time to troubleshoot via CLI.\nLiveness and Readiness probes are disabled as well.\n",
@@ -264,12 +331,13 @@
         },
         "templating": {
           "type": "object",
-          "description": "Optional, defines policy for applying current ClickHouseInstallationTemplate to ClickHouseInstallation(s)",
+          "description": "Optional, applicable inside ClickHouseInstallationTemplate only.\nDefines current ClickHouseInstallationTemplate application options to target ClickHouseInstallation(s).\"\n",
           "properties": {
             "policy": {
               "type": "string",
               "description": "When defined as `auto` inside ClickhouseInstallationTemplate, this ClickhouseInstallationTemplate\nwill be auto-added into ClickHouseInstallation, selectable by `chiSelector`.\nDefault value is `manual`, meaning ClickHouseInstallation should request this ClickhouseInstallationTemplate explicitly.\n",
               "enum": [
+                "",
                 "auto",
                 "manual"
               ]
@@ -284,11 +352,16 @@
         },
         "reconciling": {
           "type": "object",
-          "description": "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side",
+          "description": "[OBSOLETED] Optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side",
           "properties": {
             "policy": {
               "type": "string",
-              "description": "DEPRECATED"
+              "description": "DISCUSSED TO BE DEPRECATED\nSyntax sugar\nOverrides all three 'reconcile.host.wait.{exclude, queries, include}' values from the operator's config\nPossible values:\n - wait - should wait to exclude host, complete queries and include host back into the cluster\n - nowait - should NOT wait to exclude host, complete queries and include host back into the cluster\n",
+              "enum": [
+                "",
+                "wait",
+                "nowait"
+              ]
             },
             "configMapPropagationTimeout": {
               "type": "integer",
@@ -298,40 +371,44 @@
             },
             "cleanup": {
               "type": "object",
-              "description": "optional, define behavior for cleanup Kubernetes resources during reconcile cycle",
+              "description": "Optional, defines behavior for cleanup Kubernetes resources during reconcile cycle",
               "properties": {
                 "unknownObjects": {
                   "type": "object",
-                  "description": "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`",
+                  "description": "Describes what clickhouse-operator should do with found Kubernetes resources which should be managed by clickhouse-operator,\nbut do not have `ownerReference` to any currently managed `ClickHouseInstallation` resource.\nDefault behavior is `Delete`\"\n",
                   "properties": {
                     "statefulSet": {
                       "type": "string",
-                      "description": "behavior policy for unknown StatefulSet, Delete by default",
+                      "description": "Behavior policy for unknown StatefulSet, `Delete` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "pvc": {
                       "type": "string",
-                      "description": "behavior policy for unknown PVC, Delete by default",
+                      "description": "Behavior policy for unknown PVC, `Delete` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "configMap": {
                       "type": "string",
-                      "description": "behavior policy for unknown ConfigMap, Delete by default",
+                      "description": "Behavior policy for unknown ConfigMap, `Delete` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "service": {
                       "type": "string",
-                      "description": "behavior policy for unknown Service, Delete by default",
+                      "description": "Behavior policy for unknown Service, `Delete` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
@@ -341,39 +418,1408 @@
                 },
                 "reconcileFailedObjects": {
                   "type": "object",
-                  "description": "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`",
+                  "description": "Describes what clickhouse-operator should do with Kubernetes resources which are failed during reconcile.\nDefault behavior is `Retain`\"\n",
                   "properties": {
                     "statefulSet": {
                       "type": "string",
-                      "description": "behavior policy for failed StatefulSet reconciling, Retain by default",
+                      "description": "Behavior policy for failed StatefulSet, `Retain` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "pvc": {
                       "type": "string",
-                      "description": "behavior policy for failed PVC reconciling, Retain by default",
+                      "description": "Behavior policy for failed PVC, `Retain` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "configMap": {
                       "type": "string",
-                      "description": "behavior policy for failed ConfigMap reconciling, Retain by default",
+                      "description": "Behavior policy for failed ConfigMap, `Retain` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "service": {
                       "type": "string",
-                      "description": "behavior policy for failed Service reconciling, Retain by default",
+                      "description": "Behavior policy for failed Service, `Retain` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "macros": {
+              "type": "object",
+              "description": "macros parameters",
+              "properties": {
+                "sections": {
+                  "type": "object",
+                  "description": "sections behaviour for macros",
+                  "properties": {
+                    "users": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on users",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "profiles": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on profiles",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "quotas": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on quotas",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "settings": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on settings",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "files": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on files",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "runtime": {
+              "type": "object",
+              "description": "runtime parameters for clickhouse-operator process which are used during reconcile cycle",
+              "properties": {
+                "reconcileShardsThreadsNumber": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535,
+                  "description": "The maximum number of cluster shards that may be reconciled in parallel, 1 by default"
+                },
+                "reconcileShardsMaxConcurrencyPercent": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "The maximum percentage of cluster shards that may be reconciled in parallel, 50 percent by default."
+                }
+              },
+              "additionalProperties": false
+            },
+            "statefulSet": {
+              "type": "object",
+              "description": "Optional, StatefulSet reconcile behavior tuning",
+              "properties": {
+                "create": {
+                  "type": "object",
+                  "description": "Behavior during create StatefulSet",
+                  "properties": {
+                    "onFailure": {
+                      "type": "string",
+                      "description": "What to do in case created StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.\n2. delete - delete newly created problematic StatefulSet and follow 'abort' path afterwards.\n3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "delete",
+                        "ignore"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "update": {
+                  "type": "object",
+                  "description": "Behavior during update StatefulSet",
+                  "properties": {
+                    "timeout": {
+                      "type": "integer",
+                      "description": "How many seconds to wait for StatefulSet to be 'Ready' during update",
+                      "minimum": 0,
+                      "maximum": 3600
+                    },
+                    "pollInterval": {
+                      "type": "integer",
+                      "description": "How many seconds to wait between checks for StatefulSet status during update",
+                      "minimum": 1,
+                      "maximum": 600
+                    },
+                    "onFailure": {
+                      "type": "string",
+                      "description": "What to do in case updated StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.\n2. rollback - delete Pod and rollback StatefulSet to previous Generation. Follow 'abort' path afterwards.\n3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "rollback",
+                        "ignore"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "recreate": {
+                  "type": "object",
+                  "description": "Behavior during recreate StatefulSet",
+                  "properties": {
+                    "onDataLoss": {
+                      "type": "string",
+                      "description": "What to do in case operator needs to recreate StatefulSet due to PVC data loss or missing volumes.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet.\n2. recreate - proceed and recreate StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "recreate"
+                      ]
+                    },
+                    "onUpdateFailure": {
+                      "type": "string",
+                      "description": "What to do in case operator needs to recreate StatefulSet due to update failure or StatefulSet not ready.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet.\n2. recreate - proceed and recreate StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "recreate"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "host": {
+              "type": "object",
+              "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host:\n  - to be excluded from a ClickHouse cluster\n  - to complete all running queries\n  - to be included into a ClickHouse cluster\nrespectfully before moving forward\n",
+              "properties": {
+                "wait": {
+                  "type": "object",
+                  "properties": {
+                    "exclude": {
+                      "type": "string",
+                      "description": "Allows to stop all ClickHouse clusters defined in a CHI.\nWorks as the following:\n - When `stop` is `1` operator sets `Replicas: 0` in each StatefulSet. Thie leads to having all `Pods` and `Service` deleted. All PVCs are kept intact.\n - When `stop` is `0` operator sets `Replicas: 1` and `Pod`s and `Service`s will created again and all retained PVCs will be attached to `Pod`s.\n",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "queries": {
+                      "type": "string",
+                      "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to complete all running queries",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "include": {
+                      "type": "string",
+                      "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to be included into a ClickHouse cluster",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "replicas": {
+                      "type": "object",
+                      "description": "Whether the operator during reconcile procedure should wait for replicas to catch-up",
+                      "properties": {
+                        "all": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should wait for all replicas to catch-up",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "new": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should wait for new replicas to catch-up",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "delay": {
+                          "type": "integer",
+                          "description": "replication max absolute delay to consider replica is not delayed"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "probes": {
+                      "type": "object",
+                      "description": "What probes the operator should wait during host launch procedure",
+                      "properties": {
+                        "startup": {
+                          "type": "string",
+                          "description": "Whether the operator during host launch procedure should wait for startup probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to do not wait.\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "readiness": {
+                          "type": "string",
+                          "description": "Whether the operator during host launch procedure should wait for ready probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to wait.\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "drop": {
+                  "type": "object",
+                  "properties": {
+                    "replicas": {
+                      "type": "object",
+                      "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted or recreated\n",
+                      "properties": {
+                        "onDelete": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "onLostVolume": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop replicas when replica volume is lost\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "active": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop active replicas when replica is deleted or recreated\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "reconcile": {
+          "type": "object",
+          "description": "Optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side",
+          "properties": {
+            "policy": {
+              "type": "string",
+              "description": "DISCUSSED TO BE DEPRECATED\nSyntax sugar\nOverrides all three 'reconcile.host.wait.{exclude, queries, include}' values from the operator's config\nPossible values:\n - wait - should wait to exclude host, complete queries and include host back into the cluster\n - nowait - should NOT wait to exclude host, complete queries and include host back into the cluster\n",
+              "enum": [
+                "",
+                "wait",
+                "nowait"
+              ]
+            },
+            "configMapPropagationTimeout": {
+              "type": "integer",
+              "description": "Timeout in seconds for `clickhouse-operator` to wait for modified `ConfigMap` to propagate into the `Pod`\nMore details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically\n",
+              "minimum": 0,
+              "maximum": 3600
+            },
+            "cleanup": {
+              "type": "object",
+              "description": "Optional, defines behavior for cleanup Kubernetes resources during reconcile cycle",
+              "properties": {
+                "unknownObjects": {
+                  "type": "object",
+                  "description": "Describes what clickhouse-operator should do with found Kubernetes resources which should be managed by clickhouse-operator,\nbut do not have `ownerReference` to any currently managed `ClickHouseInstallation` resource.\nDefault behavior is `Delete`\"\n",
+                  "properties": {
+                    "statefulSet": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown StatefulSet, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "pvc": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown PVC, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "configMap": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown ConfigMap, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "service": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown Service, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "reconcileFailedObjects": {
+                  "type": "object",
+                  "description": "Describes what clickhouse-operator should do with Kubernetes resources which are failed during reconcile.\nDefault behavior is `Retain`\"\n",
+                  "properties": {
+                    "statefulSet": {
+                      "type": "string",
+                      "description": "Behavior policy for failed StatefulSet, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "pvc": {
+                      "type": "string",
+                      "description": "Behavior policy for failed PVC, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "configMap": {
+                      "type": "string",
+                      "description": "Behavior policy for failed ConfigMap, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "service": {
+                      "type": "string",
+                      "description": "Behavior policy for failed Service, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "macros": {
+              "type": "object",
+              "description": "macros parameters",
+              "properties": {
+                "sections": {
+                  "type": "object",
+                  "description": "sections behaviour for macros",
+                  "properties": {
+                    "users": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on users",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "profiles": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on profiles",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "quotas": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on quotas",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "settings": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on settings",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "files": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on files",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "runtime": {
+              "type": "object",
+              "description": "runtime parameters for clickhouse-operator process which are used during reconcile cycle",
+              "properties": {
+                "reconcileShardsThreadsNumber": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535,
+                  "description": "The maximum number of cluster shards that may be reconciled in parallel, 1 by default"
+                },
+                "reconcileShardsMaxConcurrencyPercent": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "The maximum percentage of cluster shards that may be reconciled in parallel, 50 percent by default."
+                }
+              },
+              "additionalProperties": false
+            },
+            "statefulSet": {
+              "type": "object",
+              "description": "Optional, StatefulSet reconcile behavior tuning",
+              "properties": {
+                "create": {
+                  "type": "object",
+                  "description": "Behavior during create StatefulSet",
+                  "properties": {
+                    "onFailure": {
+                      "type": "string",
+                      "description": "What to do in case created StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.\n2. delete - delete newly created problematic StatefulSet and follow 'abort' path afterwards.\n3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "delete",
+                        "ignore"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "update": {
+                  "type": "object",
+                  "description": "Behavior during update StatefulSet",
+                  "properties": {
+                    "timeout": {
+                      "type": "integer",
+                      "description": "How many seconds to wait for StatefulSet to be 'Ready' during update",
+                      "minimum": 0,
+                      "maximum": 3600
+                    },
+                    "pollInterval": {
+                      "type": "integer",
+                      "description": "How many seconds to wait between checks for StatefulSet status during update",
+                      "minimum": 1,
+                      "maximum": 600
+                    },
+                    "onFailure": {
+                      "type": "string",
+                      "description": "What to do in case updated StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.\n2. rollback - delete Pod and rollback StatefulSet to previous Generation. Follow 'abort' path afterwards.\n3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "rollback",
+                        "ignore"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "recreate": {
+                  "type": "object",
+                  "description": "Behavior during recreate StatefulSet",
+                  "properties": {
+                    "onDataLoss": {
+                      "type": "string",
+                      "description": "What to do in case operator needs to recreate StatefulSet due to PVC data loss or missing volumes.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet.\n2. recreate - proceed and recreate StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "recreate"
+                      ]
+                    },
+                    "onUpdateFailure": {
+                      "type": "string",
+                      "description": "What to do in case operator needs to recreate StatefulSet due to update failure or StatefulSet not ready.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet.\n2. recreate - proceed and recreate StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "recreate"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "host": {
+              "type": "object",
+              "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host:\n  - to be excluded from a ClickHouse cluster\n  - to complete all running queries\n  - to be included into a ClickHouse cluster\nrespectfully before moving forward\n",
+              "properties": {
+                "wait": {
+                  "type": "object",
+                  "properties": {
+                    "exclude": {
+                      "type": "string",
+                      "description": "Allows to stop all ClickHouse clusters defined in a CHI.\nWorks as the following:\n - When `stop` is `1` operator sets `Replicas: 0` in each StatefulSet. Thie leads to having all `Pods` and `Service` deleted. All PVCs are kept intact.\n - When `stop` is `0` operator sets `Replicas: 1` and `Pod`s and `Service`s will created again and all retained PVCs will be attached to `Pod`s.\n",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "queries": {
+                      "type": "string",
+                      "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to complete all running queries",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "include": {
+                      "type": "string",
+                      "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to be included into a ClickHouse cluster",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "replicas": {
+                      "type": "object",
+                      "description": "Whether the operator during reconcile procedure should wait for replicas to catch-up",
+                      "properties": {
+                        "all": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should wait for all replicas to catch-up",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "new": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should wait for new replicas to catch-up",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "delay": {
+                          "type": "integer",
+                          "description": "replication max absolute delay to consider replica is not delayed"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "probes": {
+                      "type": "object",
+                      "description": "What probes the operator should wait during host launch procedure",
+                      "properties": {
+                        "startup": {
+                          "type": "string",
+                          "description": "Whether the operator during host launch procedure should wait for startup probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to do not wait.\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "readiness": {
+                          "type": "string",
+                          "description": "Whether the operator during host launch procedure should wait for ready probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to wait.\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "drop": {
+                  "type": "object",
+                  "properties": {
+                    "replicas": {
+                      "type": "object",
+                      "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted or recreated\n",
+                      "properties": {
+                        "onDelete": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "onLostVolume": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop replicas when replica volume is lost\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "active": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop active replicas when replica is deleted or recreated\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
                     }
                   },
                   "additionalProperties": false
@@ -390,7 +1836,7 @@
           "properties": {
             "replicasUseFQDN": {
               "type": "string",
-              "description": "define should replicas be specified by FQDN in `<host></host>`.\nIn case of \"no\" will use short hostname and clickhouse-server will use kubernetes default suffixes for DNS lookup\n\"yes\" by default\n",
+              "description": "define should replicas be specified by FQDN in `<host></host>`.\nIn case of \"no\" will use short hostname and clickhouse-server will use kubernetes default suffixes for DNS lookup\n\"no\" by default\n",
               "enum": [
                 "",
                 "0",
@@ -475,7 +1921,15 @@
                 },
                 "serviceTemplate": {
                   "type": "string",
-                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                  "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                },
+                "serviceTemplates": {
+                  "type": "array",
+                  "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                  "nullable": true,
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "clusterServiceTemplate": {
                   "type": "string",
@@ -491,7 +1945,7 @@
                 },
                 "volumeClaimTemplate": {
                   "type": "string",
-                  "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                  "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                 }
               },
               "additionalProperties": false
@@ -551,6 +2005,10 @@
                           "Enabled",
                           "enabled"
                         ]
+                      },
+                      "availabilityZone": {
+                        "type": "string",
+                        "description": "availability zone for Zookeeper node"
                       }
                     },
                     "additionalProperties": false
@@ -571,13 +2029,42 @@
                 "identity": {
                   "type": "string",
                   "description": "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
+                },
+                "use_compression": {
+                  "type": "string",
+                  "description": "Enables compression in Keeper protocol if set to true",
+                  "enum": [
+                    "",
+                    "0",
+                    "1",
+                    "False",
+                    "false",
+                    "True",
+                    "true",
+                    "No",
+                    "no",
+                    "Yes",
+                    "yes",
+                    "Off",
+                    "off",
+                    "On",
+                    "on",
+                    "Disable",
+                    "disable",
+                    "Enable",
+                    "enable",
+                    "Disabled",
+                    "disabled",
+                    "Enabled",
+                    "enabled"
+                  ]
                 }
               },
               "additionalProperties": false
             },
             "users": {
               "type": "object",
-              "description": "allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`\nyou can configure password hashed, authorization restrictions, database level security row filters etc.\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings-users/\nYour yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers\n",
+              "description": "allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`\nyou can configure password hashed, authorization restrictions, database level security row filters etc.\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings-users/\nYour yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers\n\nany key could contains `valueFrom` with `secretKeyRef` which allow pass password from kubernetes secrets\nsecret value will pass in `pod.spec.containers.evn`, and generate with from_env=XXX in XML in /etc/clickhouse-server/users.d/chop-generated-users.xml\nit not allow automatically updates when updates `secret`, change spec.taskID for manually trigger reconcile cycle\n\nlook into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples\n\nany key with prefix `k8s_secret_` shall has value with format namespace/secret/key or secret/key\nin this case value from secret will write directly into XML tag during render *-usersd ConfigMap\n\nany key with prefix `k8s_secret_env` shall has value with format namespace/secret/key or secret/key\nin this case value from secret will write into environment variable and write to XML tag via from_env=XXX\n\nlook into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples\n",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "profiles": {
@@ -592,23 +2079,23 @@
             },
             "settings": {
               "type": "object",
-              "description": "allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings/\nYour yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings\n",
+              "description": "allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings/\nYour yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings\n\nany key could contains `valueFrom` with `secretKeyRef` which allow pass password from kubernetes secrets\nlook into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples\n\nsecret value will pass in `pod.spec.env`, and generate with from_env=XXX in XML in /etc/clickhouse-server/config.d/chop-generated-settings.xml\nit not allow automatically updates when updates `secret`, change spec.taskID for manually trigger reconcile cycle\n",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "files": {
               "type": "object",
-              "description": "allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`\nevery key in this object is the file name\nevery value in this object is the file content\nyou can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html\neach key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored\nMore details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml\n",
+              "description": "allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`\nevery key in this object is the file name\nevery value in this object is the file content\nyou can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html\neach key could contains prefix like {common}, {users}, {hosts} or config.d, users.d, conf.d, wrong prefixes will be ignored, subfolders also will be ignored\nMore details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml\n\nany key could contains `valueFrom` with `secretKeyRef` which allow pass values from kubernetes secrets\nsecrets will mounted into pod as separate volume in /etc/clickhouse-server/secrets.d/\nand will automatically update when update secret\nit useful for pass SSL certificates from cert-manager or similar tool\nlook into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples\n",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "clusters": {
               "type": "array",
-              "description": "describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level\nevery cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`\nall Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`\nClusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/\nIf `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables\n",
+              "description": "describes clusters layout and allows change settings on cluster-level, shard-level and replica-level\nevery cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`\nall Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`\nClusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/\nIf `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables\n",
               "items": {
                 "type": "object",
                 "properties": {
                   "name": {
                     "type": "string",
-                    "description": "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources",
+                    "description": "cluster name, used to identify set of servers and wide used during generate names of related Kubernetes resources",
                     "minLength": 1,
                     "maxLength": 15,
                     "pattern": "^[a-zA-Z0-9-]{0,15}$"
@@ -661,6 +2148,10 @@
                                 "Enabled",
                                 "enabled"
                               ]
+                            },
+                            "availabilityZone": {
+                              "type": "string",
+                              "description": "availability zone for Zookeeper node"
                             }
                           },
                           "additionalProperties": false
@@ -681,6 +2172,35 @@
                       "identity": {
                         "type": "string",
                         "description": "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
+                      },
+                      "use_compression": {
+                        "type": "string",
+                        "description": "Enables compression in Keeper protocol if set to true",
+                        "enum": [
+                          "",
+                          "0",
+                          "1",
+                          "False",
+                          "false",
+                          "True",
+                          "true",
+                          "No",
+                          "no",
+                          "Yes",
+                          "yes",
+                          "Off",
+                          "off",
+                          "On",
+                          "on",
+                          "Disable",
+                          "disable",
+                          "Enable",
+                          "enable",
+                          "Disabled",
+                          "disabled",
+                          "Enabled",
+                          "enabled"
+                        ]
                       }
                     },
                     "additionalProperties": false
@@ -717,7 +2237,15 @@
                       },
                       "serviceTemplate": {
                         "type": "string",
-                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                        "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                      },
+                      "serviceTemplates": {
+                        "type": "array",
+                        "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                        "nullable": true,
+                        "items": {
+                          "type": "string"
+                        }
                       },
                       "clusterServiceTemplate": {
                         "type": "string",
@@ -733,7 +2261,7 @@
                       },
                       "volumeClaimTemplate": {
                         "type": "string",
-                        "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                        "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                       }
                     },
                     "additionalProperties": false
@@ -746,6 +2274,7 @@
                         "type": "string",
                         "description": "how schema is propagated within a replica",
                         "enum": [
+                          "",
                           "None",
                           "All"
                         ]
@@ -754,6 +2283,7 @@
                         "type": "string",
                         "description": "how schema is propagated between shards",
                         "enum": [
+                          "",
                           "None",
                           "All",
                           "DistributedTablesOnly"
@@ -890,25 +2420,416 @@
                     },
                     "additionalProperties": false
                   },
+                  "pdbManaged": {
+                    "type": "string",
+                    "description": "Specifies whether the Pod Disruption Budget (PDB) should be managed.\nDuring the next installation, if PDB management is enabled, the operator will\nattempt to retrieve any existing PDB. If none is found, it will create a new one\nand initiate a reconciliation loop. If PDB management is disabled, the existing PDB\nwill remain intact, and the reconciliation loop will not be executed. By default,\nPDB management is enabled.\n",
+                    "enum": [
+                      "",
+                      "0",
+                      "1",
+                      "False",
+                      "false",
+                      "True",
+                      "true",
+                      "No",
+                      "no",
+                      "Yes",
+                      "yes",
+                      "Off",
+                      "off",
+                      "On",
+                      "on",
+                      "Disable",
+                      "disable",
+                      "Enable",
+                      "enable",
+                      "Disabled",
+                      "disabled",
+                      "Enabled",
+                      "enabled"
+                    ]
+                  },
+                  "pdbMaxUnavailable": {
+                    "type": "integer",
+                    "description": "Pod eviction is allowed if at most \"pdbMaxUnavailable\" pods are unavailable after the eviction,\ni.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions\nby specifying 0. This is a mutually exclusive setting with \"minAvailable\".\n",
+                    "minimum": 0,
+                    "maximum": 65535
+                  },
+                  "reconcile": {
+                    "type": "object",
+                    "description": "allow tuning reconciling process",
+                    "properties": {
+                      "runtime": {
+                        "type": "object",
+                        "description": "runtime parameters for clickhouse-operator process which are used during reconcile cycle",
+                        "properties": {
+                          "reconcileShardsThreadsNumber": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535,
+                            "description": "The maximum number of cluster shards that may be reconciled in parallel, 1 by default"
+                          },
+                          "reconcileShardsMaxConcurrencyPercent": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 100,
+                            "description": "The maximum percentage of cluster shards that may be reconciled in parallel, 50 percent by default."
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "host": {
+                        "type": "object",
+                        "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host:\n  - to be excluded from a ClickHouse cluster\n  - to complete all running queries\n  - to be included into a ClickHouse cluster\nrespectfully before moving forward\n",
+                        "properties": {
+                          "wait": {
+                            "type": "object",
+                            "properties": {
+                              "exclude": {
+                                "type": "string",
+                                "description": "Allows to stop all ClickHouse clusters defined in a CHI.\nWorks as the following:\n - When `stop` is `1` operator sets `Replicas: 0` in each StatefulSet. Thie leads to having all `Pods` and `Service` deleted. All PVCs are kept intact.\n - When `stop` is `0` operator sets `Replicas: 1` and `Pod`s and `Service`s will created again and all retained PVCs will be attached to `Pod`s.\n",
+                                "enum": [
+                                  "",
+                                  "0",
+                                  "1",
+                                  "False",
+                                  "false",
+                                  "True",
+                                  "true",
+                                  "No",
+                                  "no",
+                                  "Yes",
+                                  "yes",
+                                  "Off",
+                                  "off",
+                                  "On",
+                                  "on",
+                                  "Disable",
+                                  "disable",
+                                  "Enable",
+                                  "enable",
+                                  "Disabled",
+                                  "disabled",
+                                  "Enabled",
+                                  "enabled"
+                                ]
+                              },
+                              "queries": {
+                                "type": "string",
+                                "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to complete all running queries",
+                                "enum": [
+                                  "",
+                                  "0",
+                                  "1",
+                                  "False",
+                                  "false",
+                                  "True",
+                                  "true",
+                                  "No",
+                                  "no",
+                                  "Yes",
+                                  "yes",
+                                  "Off",
+                                  "off",
+                                  "On",
+                                  "on",
+                                  "Disable",
+                                  "disable",
+                                  "Enable",
+                                  "enable",
+                                  "Disabled",
+                                  "disabled",
+                                  "Enabled",
+                                  "enabled"
+                                ]
+                              },
+                              "include": {
+                                "type": "string",
+                                "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to be included into a ClickHouse cluster",
+                                "enum": [
+                                  "",
+                                  "0",
+                                  "1",
+                                  "False",
+                                  "false",
+                                  "True",
+                                  "true",
+                                  "No",
+                                  "no",
+                                  "Yes",
+                                  "yes",
+                                  "Off",
+                                  "off",
+                                  "On",
+                                  "on",
+                                  "Disable",
+                                  "disable",
+                                  "Enable",
+                                  "enable",
+                                  "Disabled",
+                                  "disabled",
+                                  "Enabled",
+                                  "enabled"
+                                ]
+                              },
+                              "replicas": {
+                                "type": "object",
+                                "description": "Whether the operator during reconcile procedure should wait for replicas to catch-up",
+                                "properties": {
+                                  "all": {
+                                    "type": "string",
+                                    "description": "Whether the operator during reconcile procedure should wait for all replicas to catch-up",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  },
+                                  "new": {
+                                    "type": "string",
+                                    "description": "Whether the operator during reconcile procedure should wait for new replicas to catch-up",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  },
+                                  "delay": {
+                                    "type": "integer",
+                                    "description": "replication max absolute delay to consider replica is not delayed"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "probes": {
+                                "type": "object",
+                                "description": "What probes the operator should wait during host launch procedure",
+                                "properties": {
+                                  "startup": {
+                                    "type": "string",
+                                    "description": "Whether the operator during host launch procedure should wait for startup probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to do not wait.\n",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  },
+                                  "readiness": {
+                                    "type": "string",
+                                    "description": "Whether the operator during host launch procedure should wait for ready probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to wait.\n",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "drop": {
+                            "type": "object",
+                            "properties": {
+                              "replicas": {
+                                "type": "object",
+                                "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted or recreated\n",
+                                "properties": {
+                                  "onDelete": {
+                                    "type": "string",
+                                    "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted\n",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  },
+                                  "onLostVolume": {
+                                    "type": "string",
+                                    "description": "Whether the operator during reconcile procedure should drop replicas when replica volume is lost\n",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  },
+                                  "active": {
+                                    "type": "string",
+                                    "description": "Whether the operator during reconcile procedure should drop active replicas when replica is deleted or recreated\n",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  },
                   "layout": {
                     "type": "object",
                     "description": "describe current cluster layout, how much shards in cluster, how much replica in shard\nallows override settings on each shard and replica separatelly\n",
                     "properties": {
-                      "type": {
-                        "type": "string",
-                        "description": "DEPRECATED - to be removed soon"
-                      },
                       "shardsCount": {
                         "type": "integer",
-                        "description": "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
+                        "description": "how much shards for current ClickHouse cluster will run in Kubernetes,\neach shard contains shared-nothing part of data and contains set of replicas,\ncluster contains 1 shard by default\"\n"
                       },
                       "replicasCount": {
                         "type": "integer",
-                        "description": "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
+                        "description": "how much replicas in each shards for current cluster will run in Kubernetes,\neach replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,\nevery shard contains 1 replica by default\"\n"
                       },
                       "shards": {
                         "type": "array",
-                        "description": "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do",
+                        "description": "optional, allows override top-level `chi.spec.configuration`, cluster-level\n`chi.spec.configuration.clusters` settings for each shard separately,\nuse it only if you fully understand what you do\"\n",
                         "items": {
                           "type": "object",
                           "properties": {
@@ -988,7 +2909,15 @@
                                 },
                                 "serviceTemplate": {
                                   "type": "string",
-                                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                                  "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                                },
+                                "serviceTemplates": {
+                                  "type": "array",
+                                  "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                                  "nullable": true,
+                                  "items": {
+                                    "type": "string"
+                                  }
                                 },
                                 "clusterServiceTemplate": {
                                   "type": "string",
@@ -1004,7 +2933,7 @@
                                 },
                                 "volumeClaimTemplate": {
                                   "type": "string",
-                                  "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                                  "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                                 }
                               },
                               "additionalProperties": false
@@ -1145,7 +3074,15 @@
                                       },
                                       "serviceTemplate": {
                                         "type": "string",
-                                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                                        "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                                      },
+                                      "serviceTemplates": {
+                                        "type": "array",
+                                        "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                                        "nullable": true,
+                                        "items": {
+                                          "type": "string"
+                                        }
                                       },
                                       "clusterServiceTemplate": {
                                         "type": "string",
@@ -1161,7 +3098,7 @@
                                       },
                                       "volumeClaimTemplate": {
                                         "type": "string",
-                                        "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                                        "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                                       }
                                     },
                                     "additionalProperties": false
@@ -1219,7 +3156,15 @@
                                 },
                                 "serviceTemplate": {
                                   "type": "string",
-                                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                                  "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                                },
+                                "serviceTemplates": {
+                                  "type": "array",
+                                  "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                                  "nullable": true,
+                                  "items": {
+                                    "type": "string"
+                                  }
                                 },
                                 "clusterServiceTemplate": {
                                   "type": "string",
@@ -1235,7 +3180,7 @@
                                 },
                                 "volumeClaimTemplate": {
                                   "type": "string",
-                                  "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                                  "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                                 }
                               },
                               "additionalProperties": false
@@ -1376,7 +3321,15 @@
                                       },
                                       "serviceTemplate": {
                                         "type": "string",
-                                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                                        "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                                      },
+                                      "serviceTemplates": {
+                                        "type": "array",
+                                        "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                                        "nullable": true,
+                                        "items": {
+                                          "type": "string"
+                                        }
                                       },
                                       "clusterServiceTemplate": {
                                         "type": "string",
@@ -1392,7 +3345,7 @@
                                       },
                                       "volumeClaimTemplate": {
                                         "type": "string",
-                                        "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                                        "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                                       }
                                     },
                                     "additionalProperties": false
@@ -1453,7 +3406,7 @@
                     "properties": {
                       "name": {
                         "type": "string",
-                        "description": "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`",
+                        "description": "by default, hostname will generate, but this allows define custom name for each `clickhouse-server`",
                         "minLength": 1,
                         "maxLength": 15,
                         "pattern": "^[a-zA-Z0-9-]{0,15}$"
@@ -1576,7 +3529,15 @@
                           },
                           "serviceTemplate": {
                             "type": "string",
-                            "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                            "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                          },
+                          "serviceTemplates": {
+                            "type": "array",
+                            "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                            "nullable": true,
+                            "items": {
+                              "type": "string"
+                            }
                           },
                           "clusterServiceTemplate": {
                             "type": "string",
@@ -1592,7 +3553,7 @@
                           },
                           "volumeClaimTemplate": {
                             "type": "string",
-                            "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                            "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                           }
                         },
                         "additionalProperties": false
@@ -1616,7 +3577,7 @@
                   },
                   "generateName": {
                     "type": "string",
-                    "description": "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
+                    "description": "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about available template variables"
                   },
                   "zone": {
                     "type": "object",
@@ -1694,20 +3655,20 @@
                         },
                         "topologyKey": {
                           "type": "string",
-                          "description": "use for inter-pod affinity look to `pod.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.topologyKey`, More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity"
+                          "description": "use for inter-pod affinity look to `pod.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.topologyKey`,\nmore info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity\"\n"
                         }
                       },
                       "additionalProperties": false
                     }
                   },
-                  "spec": {
-                    "type": "object",
-                    "description": "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details",
-                    "x-kubernetes-preserve-unknown-fields": true
-                  },
                   "metadata": {
                     "type": "object",
                     "description": "allows pass standard object's metadata from template to Pod\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\n",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "spec": {
+                    "type": "object",
+                    "description": "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details",
                     "x-kubernetes-preserve-unknown-fields": true
                   }
                 },
@@ -1716,7 +3677,7 @@
             },
             "volumeClaimTemplates": {
               "type": "array",
-              "description": "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else",
+              "description": "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else\n",
               "items": {
                 "type": "object",
                 "properties": {
@@ -1768,11 +3729,11 @@
                   },
                   "generateName": {
                     "type": "string",
-                    "description": "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
+                    "description": "allows define format for generated `Service` name,\nlook to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates\nfor details about available template variables\"\n"
                   },
                   "metadata": {
                     "type": "object",
-                    "description": "allows pass standard object's metadata from template to Service\nCould be use for define specificly for Cloud Provider metadata which impact to behavior of service\nMore info: https://kubernetes.io/docs/concepts/services-networking/service/\n",
+                    "description": "allows pass standard object's metadata from template to Service\nCould be use for define specificly for Cloud Provider metadata which impact to behavior of service\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\n",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
                   "spec": {
@@ -1789,7 +3750,7 @@
         },
         "useTemplates": {
           "type": "array",
-          "description": "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters",
+          "description": "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `CHI`\nmanifest during render Kubernetes resources to create related ClickHouse clusters\"\n",
           "items": {
             "type": "object",
             "properties": {
@@ -1799,7 +3760,7 @@
               },
               "namespace": {
                 "type": "string",
-                "description": "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
+                "description": "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clickhouse-operator`"
               },
               "useType": {
                 "type": "string",

--- a/master-standalone-strict/clickhouseinstallationtemplate-clickhouse-v1.json
+++ b/master-standalone-strict/clickhouseinstallationtemplate-clickhouse-v1.json
@@ -1,16 +1,16 @@
 {
-  "description": "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters",
+  "description": "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more clusters",
   "type": "object",
   "required": [
     "spec"
   ],
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation\nof an object. Servers should convert recognized schemas to the latest\ninternal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources\n",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this\nobject represents. Servers may infer this from the endpoint the client\nsubmits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds\n",
       "type": "string"
     },
     "metadata": {
@@ -18,23 +18,23 @@
     },
     "status": {
       "type": "object",
-      "description": "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other",
+      "description": "Status contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other\n",
       "properties": {
         "chop-version": {
           "type": "string",
-          "description": "ClickHouse operator version"
+          "description": "Operator version"
         },
         "chop-commit": {
           "type": "string",
-          "description": "ClickHouse operator git commit SHA"
+          "description": "Operator git commit SHA"
         },
         "chop-date": {
           "type": "string",
-          "description": "ClickHouse operator build date"
+          "description": "Operator build date"
         },
         "chop-ip": {
           "type": "string",
-          "description": "IP address of the operator's pod which managed this CHI"
+          "description": "IP address of the operator's pod which managed this resource"
         },
         "clusters": {
           "type": "integer",
@@ -67,6 +67,7 @@
         "taskIDsStarted": {
           "type": "array",
           "description": "Started task ids",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -74,6 +75,7 @@
         "taskIDsCompleted": {
           "type": "array",
           "description": "Completed task ids",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -85,6 +87,7 @@
         "actions": {
           "type": "array",
           "description": "Actions",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -96,9 +99,15 @@
         "errors": {
           "type": "array",
           "description": "Errors",
+          "nullable": true,
           "items": {
             "type": "string"
           }
+        },
+        "hostsUnchanged": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Unchanged Hosts count"
         },
         "hostsUpdated": {
           "type": "integer",
@@ -128,6 +137,7 @@
         "pods": {
           "type": "array",
           "description": "Pods",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -135,6 +145,7 @@
         "pod-ips": {
           "type": "array",
           "description": "Pod IPs",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -142,6 +153,7 @@
         "fqdns": {
           "type": "array",
           "description": "Pods FQDNs",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -150,6 +162,14 @@
           "type": "string",
           "description": "Endpoint"
         },
+        "endpoints": {
+          "type": "array",
+          "description": "All endpoints",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
         "generation": {
           "type": "integer",
           "minimum": 0,
@@ -157,17 +177,34 @@
         },
         "normalized": {
           "type": "object",
-          "description": "Normalized CHI requested",
+          "description": "Normalized resource requested",
+          "nullable": true,
           "x-kubernetes-preserve-unknown-fields": true
         },
         "normalizedCompleted": {
           "type": "object",
-          "description": "Normalized CHI completed",
+          "description": "Normalized resource completed",
+          "nullable": true,
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "actionPlan": {
+          "type": "object",
+          "description": "Action Plan",
+          "nullable": true,
           "x-kubernetes-preserve-unknown-fields": true
         },
         "hostsWithTablesCreated": {
           "type": "array",
           "description": "List of hosts with tables created by the operator",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "hostsWithReplicaCaughtUp": {
+          "type": "array",
+          "description": "List of hosts with replica caught up",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -175,6 +212,7 @@
         "usedTemplates": {
           "type": "array",
           "description": "List of templates used to build this CHI",
+          "nullable": true,
           "x-kubernetes-preserve-unknown-fields": true,
           "items": {
             "type": "object",
@@ -229,6 +267,35 @@
             "RollingUpdate"
           ]
         },
+        "suspend": {
+          "type": "string",
+          "description": "Suspend reconciliation of resources managed by a ClickHouse Installation.\nWorks as the following:\n - When `suspend` is `true` operator stops reconciling all resources.\n - When `suspend` is `false` or not set, operator reconciles all resources.\n",
+          "enum": [
+            "",
+            "0",
+            "1",
+            "False",
+            "false",
+            "True",
+            "true",
+            "No",
+            "no",
+            "Yes",
+            "yes",
+            "Off",
+            "off",
+            "On",
+            "on",
+            "Disable",
+            "disable",
+            "Enable",
+            "enable",
+            "Disabled",
+            "disabled",
+            "Enabled",
+            "enabled"
+          ]
+        },
         "troubleshoot": {
           "type": "string",
           "description": "Allows to troubleshoot Pods during CrashLoopBack state.\nThis may happen when wrong configuration applied, in this case `clickhouse-server` wouldn't start.\nCommand within ClickHouse container is modified with `sleep` in order to avoid quick restarts\nand give time to troubleshoot via CLI.\nLiveness and Readiness probes are disabled as well.\n",
@@ -264,12 +331,13 @@
         },
         "templating": {
           "type": "object",
-          "description": "Optional, defines policy for applying current ClickHouseInstallationTemplate to ClickHouseInstallation(s)",
+          "description": "Optional, applicable inside ClickHouseInstallationTemplate only.\nDefines current ClickHouseInstallationTemplate application options to target ClickHouseInstallation(s).\"\n",
           "properties": {
             "policy": {
               "type": "string",
               "description": "When defined as `auto` inside ClickhouseInstallationTemplate, this ClickhouseInstallationTemplate\nwill be auto-added into ClickHouseInstallation, selectable by `chiSelector`.\nDefault value is `manual`, meaning ClickHouseInstallation should request this ClickhouseInstallationTemplate explicitly.\n",
               "enum": [
+                "",
                 "auto",
                 "manual"
               ]
@@ -284,11 +352,16 @@
         },
         "reconciling": {
           "type": "object",
-          "description": "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side",
+          "description": "[OBSOLETED] Optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side",
           "properties": {
             "policy": {
               "type": "string",
-              "description": "DEPRECATED"
+              "description": "DISCUSSED TO BE DEPRECATED\nSyntax sugar\nOverrides all three 'reconcile.host.wait.{exclude, queries, include}' values from the operator's config\nPossible values:\n - wait - should wait to exclude host, complete queries and include host back into the cluster\n - nowait - should NOT wait to exclude host, complete queries and include host back into the cluster\n",
+              "enum": [
+                "",
+                "wait",
+                "nowait"
+              ]
             },
             "configMapPropagationTimeout": {
               "type": "integer",
@@ -298,40 +371,44 @@
             },
             "cleanup": {
               "type": "object",
-              "description": "optional, define behavior for cleanup Kubernetes resources during reconcile cycle",
+              "description": "Optional, defines behavior for cleanup Kubernetes resources during reconcile cycle",
               "properties": {
                 "unknownObjects": {
                   "type": "object",
-                  "description": "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`",
+                  "description": "Describes what clickhouse-operator should do with found Kubernetes resources which should be managed by clickhouse-operator,\nbut do not have `ownerReference` to any currently managed `ClickHouseInstallation` resource.\nDefault behavior is `Delete`\"\n",
                   "properties": {
                     "statefulSet": {
                       "type": "string",
-                      "description": "behavior policy for unknown StatefulSet, Delete by default",
+                      "description": "Behavior policy for unknown StatefulSet, `Delete` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "pvc": {
                       "type": "string",
-                      "description": "behavior policy for unknown PVC, Delete by default",
+                      "description": "Behavior policy for unknown PVC, `Delete` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "configMap": {
                       "type": "string",
-                      "description": "behavior policy for unknown ConfigMap, Delete by default",
+                      "description": "Behavior policy for unknown ConfigMap, `Delete` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "service": {
                       "type": "string",
-                      "description": "behavior policy for unknown Service, Delete by default",
+                      "description": "Behavior policy for unknown Service, `Delete` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
@@ -341,39 +418,1408 @@
                 },
                 "reconcileFailedObjects": {
                   "type": "object",
-                  "description": "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`",
+                  "description": "Describes what clickhouse-operator should do with Kubernetes resources which are failed during reconcile.\nDefault behavior is `Retain`\"\n",
                   "properties": {
                     "statefulSet": {
                       "type": "string",
-                      "description": "behavior policy for failed StatefulSet reconciling, Retain by default",
+                      "description": "Behavior policy for failed StatefulSet, `Retain` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "pvc": {
                       "type": "string",
-                      "description": "behavior policy for failed PVC reconciling, Retain by default",
+                      "description": "Behavior policy for failed PVC, `Retain` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "configMap": {
                       "type": "string",
-                      "description": "behavior policy for failed ConfigMap reconciling, Retain by default",
+                      "description": "Behavior policy for failed ConfigMap, `Retain` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "service": {
                       "type": "string",
-                      "description": "behavior policy for failed Service reconciling, Retain by default",
+                      "description": "Behavior policy for failed Service, `Retain` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "macros": {
+              "type": "object",
+              "description": "macros parameters",
+              "properties": {
+                "sections": {
+                  "type": "object",
+                  "description": "sections behaviour for macros",
+                  "properties": {
+                    "users": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on users",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "profiles": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on profiles",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "quotas": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on quotas",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "settings": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on settings",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "files": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on files",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "runtime": {
+              "type": "object",
+              "description": "runtime parameters for clickhouse-operator process which are used during reconcile cycle",
+              "properties": {
+                "reconcileShardsThreadsNumber": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535,
+                  "description": "The maximum number of cluster shards that may be reconciled in parallel, 1 by default"
+                },
+                "reconcileShardsMaxConcurrencyPercent": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "The maximum percentage of cluster shards that may be reconciled in parallel, 50 percent by default."
+                }
+              },
+              "additionalProperties": false
+            },
+            "statefulSet": {
+              "type": "object",
+              "description": "Optional, StatefulSet reconcile behavior tuning",
+              "properties": {
+                "create": {
+                  "type": "object",
+                  "description": "Behavior during create StatefulSet",
+                  "properties": {
+                    "onFailure": {
+                      "type": "string",
+                      "description": "What to do in case created StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.\n2. delete - delete newly created problematic StatefulSet and follow 'abort' path afterwards.\n3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "delete",
+                        "ignore"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "update": {
+                  "type": "object",
+                  "description": "Behavior during update StatefulSet",
+                  "properties": {
+                    "timeout": {
+                      "type": "integer",
+                      "description": "How many seconds to wait for StatefulSet to be 'Ready' during update",
+                      "minimum": 0,
+                      "maximum": 3600
+                    },
+                    "pollInterval": {
+                      "type": "integer",
+                      "description": "How many seconds to wait between checks for StatefulSet status during update",
+                      "minimum": 1,
+                      "maximum": 600
+                    },
+                    "onFailure": {
+                      "type": "string",
+                      "description": "What to do in case updated StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.\n2. rollback - delete Pod and rollback StatefulSet to previous Generation. Follow 'abort' path afterwards.\n3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "rollback",
+                        "ignore"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "recreate": {
+                  "type": "object",
+                  "description": "Behavior during recreate StatefulSet",
+                  "properties": {
+                    "onDataLoss": {
+                      "type": "string",
+                      "description": "What to do in case operator needs to recreate StatefulSet due to PVC data loss or missing volumes.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet.\n2. recreate - proceed and recreate StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "recreate"
+                      ]
+                    },
+                    "onUpdateFailure": {
+                      "type": "string",
+                      "description": "What to do in case operator needs to recreate StatefulSet due to update failure or StatefulSet not ready.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet.\n2. recreate - proceed and recreate StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "recreate"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "host": {
+              "type": "object",
+              "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host:\n  - to be excluded from a ClickHouse cluster\n  - to complete all running queries\n  - to be included into a ClickHouse cluster\nrespectfully before moving forward\n",
+              "properties": {
+                "wait": {
+                  "type": "object",
+                  "properties": {
+                    "exclude": {
+                      "type": "string",
+                      "description": "Allows to stop all ClickHouse clusters defined in a CHI.\nWorks as the following:\n - When `stop` is `1` operator sets `Replicas: 0` in each StatefulSet. Thie leads to having all `Pods` and `Service` deleted. All PVCs are kept intact.\n - When `stop` is `0` operator sets `Replicas: 1` and `Pod`s and `Service`s will created again and all retained PVCs will be attached to `Pod`s.\n",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "queries": {
+                      "type": "string",
+                      "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to complete all running queries",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "include": {
+                      "type": "string",
+                      "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to be included into a ClickHouse cluster",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "replicas": {
+                      "type": "object",
+                      "description": "Whether the operator during reconcile procedure should wait for replicas to catch-up",
+                      "properties": {
+                        "all": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should wait for all replicas to catch-up",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "new": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should wait for new replicas to catch-up",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "delay": {
+                          "type": "integer",
+                          "description": "replication max absolute delay to consider replica is not delayed"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "probes": {
+                      "type": "object",
+                      "description": "What probes the operator should wait during host launch procedure",
+                      "properties": {
+                        "startup": {
+                          "type": "string",
+                          "description": "Whether the operator during host launch procedure should wait for startup probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to do not wait.\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "readiness": {
+                          "type": "string",
+                          "description": "Whether the operator during host launch procedure should wait for ready probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to wait.\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "drop": {
+                  "type": "object",
+                  "properties": {
+                    "replicas": {
+                      "type": "object",
+                      "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted or recreated\n",
+                      "properties": {
+                        "onDelete": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "onLostVolume": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop replicas when replica volume is lost\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "active": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop active replicas when replica is deleted or recreated\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "reconcile": {
+          "type": "object",
+          "description": "Optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side",
+          "properties": {
+            "policy": {
+              "type": "string",
+              "description": "DISCUSSED TO BE DEPRECATED\nSyntax sugar\nOverrides all three 'reconcile.host.wait.{exclude, queries, include}' values from the operator's config\nPossible values:\n - wait - should wait to exclude host, complete queries and include host back into the cluster\n - nowait - should NOT wait to exclude host, complete queries and include host back into the cluster\n",
+              "enum": [
+                "",
+                "wait",
+                "nowait"
+              ]
+            },
+            "configMapPropagationTimeout": {
+              "type": "integer",
+              "description": "Timeout in seconds for `clickhouse-operator` to wait for modified `ConfigMap` to propagate into the `Pod`\nMore details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically\n",
+              "minimum": 0,
+              "maximum": 3600
+            },
+            "cleanup": {
+              "type": "object",
+              "description": "Optional, defines behavior for cleanup Kubernetes resources during reconcile cycle",
+              "properties": {
+                "unknownObjects": {
+                  "type": "object",
+                  "description": "Describes what clickhouse-operator should do with found Kubernetes resources which should be managed by clickhouse-operator,\nbut do not have `ownerReference` to any currently managed `ClickHouseInstallation` resource.\nDefault behavior is `Delete`\"\n",
+                  "properties": {
+                    "statefulSet": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown StatefulSet, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "pvc": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown PVC, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "configMap": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown ConfigMap, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "service": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown Service, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "reconcileFailedObjects": {
+                  "type": "object",
+                  "description": "Describes what clickhouse-operator should do with Kubernetes resources which are failed during reconcile.\nDefault behavior is `Retain`\"\n",
+                  "properties": {
+                    "statefulSet": {
+                      "type": "string",
+                      "description": "Behavior policy for failed StatefulSet, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "pvc": {
+                      "type": "string",
+                      "description": "Behavior policy for failed PVC, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "configMap": {
+                      "type": "string",
+                      "description": "Behavior policy for failed ConfigMap, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "service": {
+                      "type": "string",
+                      "description": "Behavior policy for failed Service, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "macros": {
+              "type": "object",
+              "description": "macros parameters",
+              "properties": {
+                "sections": {
+                  "type": "object",
+                  "description": "sections behaviour for macros",
+                  "properties": {
+                    "users": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on users",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "profiles": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on profiles",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "quotas": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on quotas",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "settings": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on settings",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "files": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on files",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "runtime": {
+              "type": "object",
+              "description": "runtime parameters for clickhouse-operator process which are used during reconcile cycle",
+              "properties": {
+                "reconcileShardsThreadsNumber": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535,
+                  "description": "The maximum number of cluster shards that may be reconciled in parallel, 1 by default"
+                },
+                "reconcileShardsMaxConcurrencyPercent": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "The maximum percentage of cluster shards that may be reconciled in parallel, 50 percent by default."
+                }
+              },
+              "additionalProperties": false
+            },
+            "statefulSet": {
+              "type": "object",
+              "description": "Optional, StatefulSet reconcile behavior tuning",
+              "properties": {
+                "create": {
+                  "type": "object",
+                  "description": "Behavior during create StatefulSet",
+                  "properties": {
+                    "onFailure": {
+                      "type": "string",
+                      "description": "What to do in case created StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.\n2. delete - delete newly created problematic StatefulSet and follow 'abort' path afterwards.\n3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "delete",
+                        "ignore"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "update": {
+                  "type": "object",
+                  "description": "Behavior during update StatefulSet",
+                  "properties": {
+                    "timeout": {
+                      "type": "integer",
+                      "description": "How many seconds to wait for StatefulSet to be 'Ready' during update",
+                      "minimum": 0,
+                      "maximum": 3600
+                    },
+                    "pollInterval": {
+                      "type": "integer",
+                      "description": "How many seconds to wait between checks for StatefulSet status during update",
+                      "minimum": 1,
+                      "maximum": 600
+                    },
+                    "onFailure": {
+                      "type": "string",
+                      "description": "What to do in case updated StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.\n2. rollback - delete Pod and rollback StatefulSet to previous Generation. Follow 'abort' path afterwards.\n3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "rollback",
+                        "ignore"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "recreate": {
+                  "type": "object",
+                  "description": "Behavior during recreate StatefulSet",
+                  "properties": {
+                    "onDataLoss": {
+                      "type": "string",
+                      "description": "What to do in case operator needs to recreate StatefulSet due to PVC data loss or missing volumes.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet.\n2. recreate - proceed and recreate StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "recreate"
+                      ]
+                    },
+                    "onUpdateFailure": {
+                      "type": "string",
+                      "description": "What to do in case operator needs to recreate StatefulSet due to update failure or StatefulSet not ready.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet.\n2. recreate - proceed and recreate StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "recreate"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "host": {
+              "type": "object",
+              "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host:\n  - to be excluded from a ClickHouse cluster\n  - to complete all running queries\n  - to be included into a ClickHouse cluster\nrespectfully before moving forward\n",
+              "properties": {
+                "wait": {
+                  "type": "object",
+                  "properties": {
+                    "exclude": {
+                      "type": "string",
+                      "description": "Allows to stop all ClickHouse clusters defined in a CHI.\nWorks as the following:\n - When `stop` is `1` operator sets `Replicas: 0` in each StatefulSet. Thie leads to having all `Pods` and `Service` deleted. All PVCs are kept intact.\n - When `stop` is `0` operator sets `Replicas: 1` and `Pod`s and `Service`s will created again and all retained PVCs will be attached to `Pod`s.\n",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "queries": {
+                      "type": "string",
+                      "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to complete all running queries",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "include": {
+                      "type": "string",
+                      "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to be included into a ClickHouse cluster",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "replicas": {
+                      "type": "object",
+                      "description": "Whether the operator during reconcile procedure should wait for replicas to catch-up",
+                      "properties": {
+                        "all": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should wait for all replicas to catch-up",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "new": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should wait for new replicas to catch-up",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "delay": {
+                          "type": "integer",
+                          "description": "replication max absolute delay to consider replica is not delayed"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "probes": {
+                      "type": "object",
+                      "description": "What probes the operator should wait during host launch procedure",
+                      "properties": {
+                        "startup": {
+                          "type": "string",
+                          "description": "Whether the operator during host launch procedure should wait for startup probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to do not wait.\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "readiness": {
+                          "type": "string",
+                          "description": "Whether the operator during host launch procedure should wait for ready probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to wait.\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "drop": {
+                  "type": "object",
+                  "properties": {
+                    "replicas": {
+                      "type": "object",
+                      "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted or recreated\n",
+                      "properties": {
+                        "onDelete": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "onLostVolume": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop replicas when replica volume is lost\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "active": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop active replicas when replica is deleted or recreated\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
                     }
                   },
                   "additionalProperties": false
@@ -390,7 +1836,7 @@
           "properties": {
             "replicasUseFQDN": {
               "type": "string",
-              "description": "define should replicas be specified by FQDN in `<host></host>`.\nIn case of \"no\" will use short hostname and clickhouse-server will use kubernetes default suffixes for DNS lookup\n\"yes\" by default\n",
+              "description": "define should replicas be specified by FQDN in `<host></host>`.\nIn case of \"no\" will use short hostname and clickhouse-server will use kubernetes default suffixes for DNS lookup\n\"no\" by default\n",
               "enum": [
                 "",
                 "0",
@@ -475,7 +1921,15 @@
                 },
                 "serviceTemplate": {
                   "type": "string",
-                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                  "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                },
+                "serviceTemplates": {
+                  "type": "array",
+                  "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                  "nullable": true,
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "clusterServiceTemplate": {
                   "type": "string",
@@ -491,7 +1945,7 @@
                 },
                 "volumeClaimTemplate": {
                   "type": "string",
-                  "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                  "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                 }
               },
               "additionalProperties": false
@@ -551,6 +2005,10 @@
                           "Enabled",
                           "enabled"
                         ]
+                      },
+                      "availabilityZone": {
+                        "type": "string",
+                        "description": "availability zone for Zookeeper node"
                       }
                     },
                     "additionalProperties": false
@@ -571,13 +2029,42 @@
                 "identity": {
                   "type": "string",
                   "description": "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
+                },
+                "use_compression": {
+                  "type": "string",
+                  "description": "Enables compression in Keeper protocol if set to true",
+                  "enum": [
+                    "",
+                    "0",
+                    "1",
+                    "False",
+                    "false",
+                    "True",
+                    "true",
+                    "No",
+                    "no",
+                    "Yes",
+                    "yes",
+                    "Off",
+                    "off",
+                    "On",
+                    "on",
+                    "Disable",
+                    "disable",
+                    "Enable",
+                    "enable",
+                    "Disabled",
+                    "disabled",
+                    "Enabled",
+                    "enabled"
+                  ]
                 }
               },
               "additionalProperties": false
             },
             "users": {
               "type": "object",
-              "description": "allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`\nyou can configure password hashed, authorization restrictions, database level security row filters etc.\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings-users/\nYour yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers\n",
+              "description": "allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`\nyou can configure password hashed, authorization restrictions, database level security row filters etc.\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings-users/\nYour yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers\n\nany key could contains `valueFrom` with `secretKeyRef` which allow pass password from kubernetes secrets\nsecret value will pass in `pod.spec.containers.evn`, and generate with from_env=XXX in XML in /etc/clickhouse-server/users.d/chop-generated-users.xml\nit not allow automatically updates when updates `secret`, change spec.taskID for manually trigger reconcile cycle\n\nlook into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples\n\nany key with prefix `k8s_secret_` shall has value with format namespace/secret/key or secret/key\nin this case value from secret will write directly into XML tag during render *-usersd ConfigMap\n\nany key with prefix `k8s_secret_env` shall has value with format namespace/secret/key or secret/key\nin this case value from secret will write into environment variable and write to XML tag via from_env=XXX\n\nlook into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples\n",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "profiles": {
@@ -592,23 +2079,23 @@
             },
             "settings": {
               "type": "object",
-              "description": "allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings/\nYour yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings\n",
+              "description": "allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings/\nYour yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings\n\nany key could contains `valueFrom` with `secretKeyRef` which allow pass password from kubernetes secrets\nlook into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples\n\nsecret value will pass in `pod.spec.env`, and generate with from_env=XXX in XML in /etc/clickhouse-server/config.d/chop-generated-settings.xml\nit not allow automatically updates when updates `secret`, change spec.taskID for manually trigger reconcile cycle\n",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "files": {
               "type": "object",
-              "description": "allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`\nevery key in this object is the file name\nevery value in this object is the file content\nyou can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html\neach key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored\nMore details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml\n",
+              "description": "allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`\nevery key in this object is the file name\nevery value in this object is the file content\nyou can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html\neach key could contains prefix like {common}, {users}, {hosts} or config.d, users.d, conf.d, wrong prefixes will be ignored, subfolders also will be ignored\nMore details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml\n\nany key could contains `valueFrom` with `secretKeyRef` which allow pass values from kubernetes secrets\nsecrets will mounted into pod as separate volume in /etc/clickhouse-server/secrets.d/\nand will automatically update when update secret\nit useful for pass SSL certificates from cert-manager or similar tool\nlook into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples\n",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "clusters": {
               "type": "array",
-              "description": "describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level\nevery cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`\nall Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`\nClusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/\nIf `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables\n",
+              "description": "describes clusters layout and allows change settings on cluster-level, shard-level and replica-level\nevery cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`\nall Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`\nClusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/\nIf `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables\n",
               "items": {
                 "type": "object",
                 "properties": {
                   "name": {
                     "type": "string",
-                    "description": "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources",
+                    "description": "cluster name, used to identify set of servers and wide used during generate names of related Kubernetes resources",
                     "minLength": 1,
                     "maxLength": 15,
                     "pattern": "^[a-zA-Z0-9-]{0,15}$"
@@ -661,6 +2148,10 @@
                                 "Enabled",
                                 "enabled"
                               ]
+                            },
+                            "availabilityZone": {
+                              "type": "string",
+                              "description": "availability zone for Zookeeper node"
                             }
                           },
                           "additionalProperties": false
@@ -681,6 +2172,35 @@
                       "identity": {
                         "type": "string",
                         "description": "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
+                      },
+                      "use_compression": {
+                        "type": "string",
+                        "description": "Enables compression in Keeper protocol if set to true",
+                        "enum": [
+                          "",
+                          "0",
+                          "1",
+                          "False",
+                          "false",
+                          "True",
+                          "true",
+                          "No",
+                          "no",
+                          "Yes",
+                          "yes",
+                          "Off",
+                          "off",
+                          "On",
+                          "on",
+                          "Disable",
+                          "disable",
+                          "Enable",
+                          "enable",
+                          "Disabled",
+                          "disabled",
+                          "Enabled",
+                          "enabled"
+                        ]
                       }
                     },
                     "additionalProperties": false
@@ -717,7 +2237,15 @@
                       },
                       "serviceTemplate": {
                         "type": "string",
-                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                        "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                      },
+                      "serviceTemplates": {
+                        "type": "array",
+                        "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                        "nullable": true,
+                        "items": {
+                          "type": "string"
+                        }
                       },
                       "clusterServiceTemplate": {
                         "type": "string",
@@ -733,7 +2261,7 @@
                       },
                       "volumeClaimTemplate": {
                         "type": "string",
-                        "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                        "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                       }
                     },
                     "additionalProperties": false
@@ -746,6 +2274,7 @@
                         "type": "string",
                         "description": "how schema is propagated within a replica",
                         "enum": [
+                          "",
                           "None",
                           "All"
                         ]
@@ -754,6 +2283,7 @@
                         "type": "string",
                         "description": "how schema is propagated between shards",
                         "enum": [
+                          "",
                           "None",
                           "All",
                           "DistributedTablesOnly"
@@ -890,25 +2420,416 @@
                     },
                     "additionalProperties": false
                   },
+                  "pdbManaged": {
+                    "type": "string",
+                    "description": "Specifies whether the Pod Disruption Budget (PDB) should be managed.\nDuring the next installation, if PDB management is enabled, the operator will\nattempt to retrieve any existing PDB. If none is found, it will create a new one\nand initiate a reconciliation loop. If PDB management is disabled, the existing PDB\nwill remain intact, and the reconciliation loop will not be executed. By default,\nPDB management is enabled.\n",
+                    "enum": [
+                      "",
+                      "0",
+                      "1",
+                      "False",
+                      "false",
+                      "True",
+                      "true",
+                      "No",
+                      "no",
+                      "Yes",
+                      "yes",
+                      "Off",
+                      "off",
+                      "On",
+                      "on",
+                      "Disable",
+                      "disable",
+                      "Enable",
+                      "enable",
+                      "Disabled",
+                      "disabled",
+                      "Enabled",
+                      "enabled"
+                    ]
+                  },
+                  "pdbMaxUnavailable": {
+                    "type": "integer",
+                    "description": "Pod eviction is allowed if at most \"pdbMaxUnavailable\" pods are unavailable after the eviction,\ni.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions\nby specifying 0. This is a mutually exclusive setting with \"minAvailable\".\n",
+                    "minimum": 0,
+                    "maximum": 65535
+                  },
+                  "reconcile": {
+                    "type": "object",
+                    "description": "allow tuning reconciling process",
+                    "properties": {
+                      "runtime": {
+                        "type": "object",
+                        "description": "runtime parameters for clickhouse-operator process which are used during reconcile cycle",
+                        "properties": {
+                          "reconcileShardsThreadsNumber": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535,
+                            "description": "The maximum number of cluster shards that may be reconciled in parallel, 1 by default"
+                          },
+                          "reconcileShardsMaxConcurrencyPercent": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 100,
+                            "description": "The maximum percentage of cluster shards that may be reconciled in parallel, 50 percent by default."
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "host": {
+                        "type": "object",
+                        "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host:\n  - to be excluded from a ClickHouse cluster\n  - to complete all running queries\n  - to be included into a ClickHouse cluster\nrespectfully before moving forward\n",
+                        "properties": {
+                          "wait": {
+                            "type": "object",
+                            "properties": {
+                              "exclude": {
+                                "type": "string",
+                                "description": "Allows to stop all ClickHouse clusters defined in a CHI.\nWorks as the following:\n - When `stop` is `1` operator sets `Replicas: 0` in each StatefulSet. Thie leads to having all `Pods` and `Service` deleted. All PVCs are kept intact.\n - When `stop` is `0` operator sets `Replicas: 1` and `Pod`s and `Service`s will created again and all retained PVCs will be attached to `Pod`s.\n",
+                                "enum": [
+                                  "",
+                                  "0",
+                                  "1",
+                                  "False",
+                                  "false",
+                                  "True",
+                                  "true",
+                                  "No",
+                                  "no",
+                                  "Yes",
+                                  "yes",
+                                  "Off",
+                                  "off",
+                                  "On",
+                                  "on",
+                                  "Disable",
+                                  "disable",
+                                  "Enable",
+                                  "enable",
+                                  "Disabled",
+                                  "disabled",
+                                  "Enabled",
+                                  "enabled"
+                                ]
+                              },
+                              "queries": {
+                                "type": "string",
+                                "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to complete all running queries",
+                                "enum": [
+                                  "",
+                                  "0",
+                                  "1",
+                                  "False",
+                                  "false",
+                                  "True",
+                                  "true",
+                                  "No",
+                                  "no",
+                                  "Yes",
+                                  "yes",
+                                  "Off",
+                                  "off",
+                                  "On",
+                                  "on",
+                                  "Disable",
+                                  "disable",
+                                  "Enable",
+                                  "enable",
+                                  "Disabled",
+                                  "disabled",
+                                  "Enabled",
+                                  "enabled"
+                                ]
+                              },
+                              "include": {
+                                "type": "string",
+                                "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to be included into a ClickHouse cluster",
+                                "enum": [
+                                  "",
+                                  "0",
+                                  "1",
+                                  "False",
+                                  "false",
+                                  "True",
+                                  "true",
+                                  "No",
+                                  "no",
+                                  "Yes",
+                                  "yes",
+                                  "Off",
+                                  "off",
+                                  "On",
+                                  "on",
+                                  "Disable",
+                                  "disable",
+                                  "Enable",
+                                  "enable",
+                                  "Disabled",
+                                  "disabled",
+                                  "Enabled",
+                                  "enabled"
+                                ]
+                              },
+                              "replicas": {
+                                "type": "object",
+                                "description": "Whether the operator during reconcile procedure should wait for replicas to catch-up",
+                                "properties": {
+                                  "all": {
+                                    "type": "string",
+                                    "description": "Whether the operator during reconcile procedure should wait for all replicas to catch-up",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  },
+                                  "new": {
+                                    "type": "string",
+                                    "description": "Whether the operator during reconcile procedure should wait for new replicas to catch-up",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  },
+                                  "delay": {
+                                    "type": "integer",
+                                    "description": "replication max absolute delay to consider replica is not delayed"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "probes": {
+                                "type": "object",
+                                "description": "What probes the operator should wait during host launch procedure",
+                                "properties": {
+                                  "startup": {
+                                    "type": "string",
+                                    "description": "Whether the operator during host launch procedure should wait for startup probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to do not wait.\n",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  },
+                                  "readiness": {
+                                    "type": "string",
+                                    "description": "Whether the operator during host launch procedure should wait for ready probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to wait.\n",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "drop": {
+                            "type": "object",
+                            "properties": {
+                              "replicas": {
+                                "type": "object",
+                                "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted or recreated\n",
+                                "properties": {
+                                  "onDelete": {
+                                    "type": "string",
+                                    "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted\n",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  },
+                                  "onLostVolume": {
+                                    "type": "string",
+                                    "description": "Whether the operator during reconcile procedure should drop replicas when replica volume is lost\n",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  },
+                                  "active": {
+                                    "type": "string",
+                                    "description": "Whether the operator during reconcile procedure should drop active replicas when replica is deleted or recreated\n",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  },
                   "layout": {
                     "type": "object",
                     "description": "describe current cluster layout, how much shards in cluster, how much replica in shard\nallows override settings on each shard and replica separatelly\n",
                     "properties": {
-                      "type": {
-                        "type": "string",
-                        "description": "DEPRECATED - to be removed soon"
-                      },
                       "shardsCount": {
                         "type": "integer",
-                        "description": "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
+                        "description": "how much shards for current ClickHouse cluster will run in Kubernetes,\neach shard contains shared-nothing part of data and contains set of replicas,\ncluster contains 1 shard by default\"\n"
                       },
                       "replicasCount": {
                         "type": "integer",
-                        "description": "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
+                        "description": "how much replicas in each shards for current cluster will run in Kubernetes,\neach replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,\nevery shard contains 1 replica by default\"\n"
                       },
                       "shards": {
                         "type": "array",
-                        "description": "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do",
+                        "description": "optional, allows override top-level `chi.spec.configuration`, cluster-level\n`chi.spec.configuration.clusters` settings for each shard separately,\nuse it only if you fully understand what you do\"\n",
                         "items": {
                           "type": "object",
                           "properties": {
@@ -988,7 +2909,15 @@
                                 },
                                 "serviceTemplate": {
                                   "type": "string",
-                                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                                  "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                                },
+                                "serviceTemplates": {
+                                  "type": "array",
+                                  "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                                  "nullable": true,
+                                  "items": {
+                                    "type": "string"
+                                  }
                                 },
                                 "clusterServiceTemplate": {
                                   "type": "string",
@@ -1004,7 +2933,7 @@
                                 },
                                 "volumeClaimTemplate": {
                                   "type": "string",
-                                  "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                                  "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                                 }
                               },
                               "additionalProperties": false
@@ -1145,7 +3074,15 @@
                                       },
                                       "serviceTemplate": {
                                         "type": "string",
-                                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                                        "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                                      },
+                                      "serviceTemplates": {
+                                        "type": "array",
+                                        "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                                        "nullable": true,
+                                        "items": {
+                                          "type": "string"
+                                        }
                                       },
                                       "clusterServiceTemplate": {
                                         "type": "string",
@@ -1161,7 +3098,7 @@
                                       },
                                       "volumeClaimTemplate": {
                                         "type": "string",
-                                        "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                                        "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                                       }
                                     },
                                     "additionalProperties": false
@@ -1219,7 +3156,15 @@
                                 },
                                 "serviceTemplate": {
                                   "type": "string",
-                                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                                  "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                                },
+                                "serviceTemplates": {
+                                  "type": "array",
+                                  "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                                  "nullable": true,
+                                  "items": {
+                                    "type": "string"
+                                  }
                                 },
                                 "clusterServiceTemplate": {
                                   "type": "string",
@@ -1235,7 +3180,7 @@
                                 },
                                 "volumeClaimTemplate": {
                                   "type": "string",
-                                  "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                                  "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                                 }
                               },
                               "additionalProperties": false
@@ -1376,7 +3321,15 @@
                                       },
                                       "serviceTemplate": {
                                         "type": "string",
-                                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                                        "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                                      },
+                                      "serviceTemplates": {
+                                        "type": "array",
+                                        "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                                        "nullable": true,
+                                        "items": {
+                                          "type": "string"
+                                        }
                                       },
                                       "clusterServiceTemplate": {
                                         "type": "string",
@@ -1392,7 +3345,7 @@
                                       },
                                       "volumeClaimTemplate": {
                                         "type": "string",
-                                        "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                                        "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                                       }
                                     },
                                     "additionalProperties": false
@@ -1453,7 +3406,7 @@
                     "properties": {
                       "name": {
                         "type": "string",
-                        "description": "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`",
+                        "description": "by default, hostname will generate, but this allows define custom name for each `clickhouse-server`",
                         "minLength": 1,
                         "maxLength": 15,
                         "pattern": "^[a-zA-Z0-9-]{0,15}$"
@@ -1576,7 +3529,15 @@
                           },
                           "serviceTemplate": {
                             "type": "string",
-                            "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                            "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                          },
+                          "serviceTemplates": {
+                            "type": "array",
+                            "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                            "nullable": true,
+                            "items": {
+                              "type": "string"
+                            }
                           },
                           "clusterServiceTemplate": {
                             "type": "string",
@@ -1592,7 +3553,7 @@
                           },
                           "volumeClaimTemplate": {
                             "type": "string",
-                            "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                            "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                           }
                         },
                         "additionalProperties": false
@@ -1616,7 +3577,7 @@
                   },
                   "generateName": {
                     "type": "string",
-                    "description": "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
+                    "description": "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about available template variables"
                   },
                   "zone": {
                     "type": "object",
@@ -1694,20 +3655,20 @@
                         },
                         "topologyKey": {
                           "type": "string",
-                          "description": "use for inter-pod affinity look to `pod.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.topologyKey`, More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity"
+                          "description": "use for inter-pod affinity look to `pod.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.topologyKey`,\nmore info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity\"\n"
                         }
                       },
                       "additionalProperties": false
                     }
                   },
-                  "spec": {
-                    "type": "object",
-                    "description": "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details",
-                    "x-kubernetes-preserve-unknown-fields": true
-                  },
                   "metadata": {
                     "type": "object",
                     "description": "allows pass standard object's metadata from template to Pod\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\n",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "spec": {
+                    "type": "object",
+                    "description": "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details",
                     "x-kubernetes-preserve-unknown-fields": true
                   }
                 },
@@ -1716,7 +3677,7 @@
             },
             "volumeClaimTemplates": {
               "type": "array",
-              "description": "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else",
+              "description": "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else\n",
               "items": {
                 "type": "object",
                 "properties": {
@@ -1768,11 +3729,11 @@
                   },
                   "generateName": {
                     "type": "string",
-                    "description": "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
+                    "description": "allows define format for generated `Service` name,\nlook to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates\nfor details about available template variables\"\n"
                   },
                   "metadata": {
                     "type": "object",
-                    "description": "allows pass standard object's metadata from template to Service\nCould be use for define specificly for Cloud Provider metadata which impact to behavior of service\nMore info: https://kubernetes.io/docs/concepts/services-networking/service/\n",
+                    "description": "allows pass standard object's metadata from template to Service\nCould be use for define specificly for Cloud Provider metadata which impact to behavior of service\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\n",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
                   "spec": {
@@ -1789,7 +3750,7 @@
         },
         "useTemplates": {
           "type": "array",
-          "description": "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters",
+          "description": "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `CHI`\nmanifest during render Kubernetes resources to create related ClickHouse clusters\"\n",
           "items": {
             "type": "object",
             "properties": {
@@ -1799,7 +3760,7 @@
               },
               "namespace": {
                 "type": "string",
-                "description": "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
+                "description": "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clickhouse-operator`"
               },
               "useType": {
                 "type": "string",

--- a/master-standalone-strict/clickhousekeeperinstallation-clickhouse-keeper-v1.json
+++ b/master-standalone-strict/clickhousekeeperinstallation-clickhouse-keeper-v1.json
@@ -1,0 +1,1147 @@
+{
+  "description": "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more clusters",
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation\nof an object. Servers should convert recognized schemas to the latest\ninternal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources\n",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this\nobject represents. Servers may infer this from the endpoint the client\nsubmits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds\n",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "status": {
+      "type": "object",
+      "description": "Status contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other\n",
+      "properties": {
+        "chop-version": {
+          "type": "string",
+          "description": "Operator version"
+        },
+        "chop-commit": {
+          "type": "string",
+          "description": "Operator git commit SHA"
+        },
+        "chop-date": {
+          "type": "string",
+          "description": "Operator build date"
+        },
+        "chop-ip": {
+          "type": "string",
+          "description": "IP address of the operator's pod which managed this resource"
+        },
+        "clusters": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Clusters count"
+        },
+        "shards": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Shards count"
+        },
+        "replicas": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Replicas count"
+        },
+        "hosts": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Hosts count"
+        },
+        "status": {
+          "type": "string",
+          "description": "Status"
+        },
+        "taskID": {
+          "type": "string",
+          "description": "Current task id"
+        },
+        "taskIDsStarted": {
+          "type": "array",
+          "description": "Started task ids",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "taskIDsCompleted": {
+          "type": "array",
+          "description": "Completed task ids",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "action": {
+          "type": "string",
+          "description": "Action"
+        },
+        "actions": {
+          "type": "array",
+          "description": "Actions",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "error": {
+          "type": "string",
+          "description": "Last error"
+        },
+        "errors": {
+          "type": "array",
+          "description": "Errors",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "hostsUnchanged": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Unchanged Hosts count"
+        },
+        "hostsUpdated": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Updated Hosts count"
+        },
+        "hostsAdded": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Added Hosts count"
+        },
+        "hostsCompleted": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Completed Hosts count"
+        },
+        "hostsDeleted": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Deleted Hosts count"
+        },
+        "hostsDelete": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "About to delete Hosts count"
+        },
+        "pods": {
+          "type": "array",
+          "description": "Pods",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "pod-ips": {
+          "type": "array",
+          "description": "Pod IPs",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "fqdns": {
+          "type": "array",
+          "description": "Pods FQDNs",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "Endpoint"
+        },
+        "endpoints": {
+          "type": "array",
+          "description": "All endpoints",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "generation": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Generation"
+        },
+        "normalized": {
+          "type": "object",
+          "description": "Normalized resource requested",
+          "nullable": true,
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "normalizedCompleted": {
+          "type": "object",
+          "description": "Normalized resource completed",
+          "nullable": true,
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "hostsWithTablesCreated": {
+          "type": "array",
+          "description": "List of hosts with tables created by the operator",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "hostsWithReplicaCaughtUp": {
+          "type": "array",
+          "description": "List of hosts with replica caught up",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "usedTemplates": {
+          "type": "array",
+          "description": "List of templates used to build this CHI",
+          "nullable": true,
+          "x-kubernetes-preserve-unknown-fields": true,
+          "items": {
+            "type": "object",
+            "x-kubernetes-preserve-unknown-fields": true
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "spec": {
+      "type": "object",
+      "description": "Specification of the desired behavior of one or more ClickHouse clusters\nMore info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md\n",
+      "properties": {
+        "taskID": {
+          "type": "string",
+          "description": "Allows to define custom taskID for CHI update and watch status of this update execution.\nDisplayed in all .status.taskID* fields.\nBy default (if not filled) every update of CHI manifest will generate random taskID\n"
+        },
+        "stop": {
+          "type": "string",
+          "description": "Allows to stop all ClickHouse Keeper clusters defined in a CHK.\nWorks as the following:\n - When `stop` is `1` operator sets `Replicas: 0` in each StatefulSet. Thie leads to having all `Pods` and `Service` deleted. All PVCs are kept intact.\n - When `stop` is `0` operator sets `Replicas: 1` and `Pod`s and `Service`s will created again and all retained PVCs will be attached to `Pod`s.\n",
+          "enum": [
+            "",
+            "0",
+            "1",
+            "False",
+            "false",
+            "True",
+            "true",
+            "No",
+            "no",
+            "Yes",
+            "yes",
+            "Off",
+            "off",
+            "On",
+            "on",
+            "Disable",
+            "disable",
+            "Enable",
+            "enable",
+            "Disabled",
+            "disabled",
+            "Enabled",
+            "enabled"
+          ]
+        },
+        "suspend": {
+          "type": "string",
+          "description": "Suspend reconciliation of resources managed by a ClickHouse Keeper.\nWorks as the following:\n - When `suspend` is `true` operator stops reconciling all resources.\n - When `suspend` is `false` or not set, operator reconciles all resources.\n",
+          "enum": [
+            "",
+            "0",
+            "1",
+            "False",
+            "false",
+            "True",
+            "true",
+            "No",
+            "no",
+            "Yes",
+            "yes",
+            "Off",
+            "off",
+            "On",
+            "on",
+            "Disable",
+            "disable",
+            "Enable",
+            "enable",
+            "Disabled",
+            "disabled",
+            "Enabled",
+            "enabled"
+          ]
+        },
+        "namespaceDomainPattern": {
+          "type": "string",
+          "description": "Custom domain pattern which will be used for DNS names of `Service` or `Pod`.\nTypical use scenario - custom cluster domain in Kubernetes cluster\nExample: %s.svc.my.test\n"
+        },
+        "reconciling": {
+          "type": "object",
+          "description": "Optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side",
+          "properties": {
+            "policy": {
+              "type": "string",
+              "description": "DISCUSSED TO BE DEPRECATED\nSyntax sugar\nOverrides all three 'reconcile.host.wait.{exclude, queries, include}' values from the operator's config\nPossible values:\n - wait - should wait to exclude host, complete queries and include host back into the cluster\n - nowait - should NOT wait to exclude host, complete queries and include host back into the cluster\n",
+              "enum": [
+                "",
+                "wait",
+                "nowait"
+              ]
+            },
+            "configMapPropagationTimeout": {
+              "type": "integer",
+              "description": "Timeout in seconds for `clickhouse-operator` to wait for modified `ConfigMap` to propagate into the `Pod`\nMore details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically\n",
+              "minimum": 0,
+              "maximum": 3600
+            },
+            "cleanup": {
+              "type": "object",
+              "description": "Optional, defines behavior for cleanup Kubernetes resources during reconcile cycle",
+              "properties": {
+                "unknownObjects": {
+                  "type": "object",
+                  "description": "Describes what clickhouse-operator should do with found Kubernetes resources which should be managed by clickhouse-operator,\nbut do not have `ownerReference` to any currently managed `ClickHouseInstallation` resource.\nDefault behavior is `Delete`\"\n",
+                  "properties": {
+                    "statefulSet": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown StatefulSet, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "pvc": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown PVC, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "configMap": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown ConfigMap, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "service": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown Service, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "reconcileFailedObjects": {
+                  "type": "object",
+                  "description": "Describes what clickhouse-operator should do with Kubernetes resources which are failed during reconcile.\nDefault behavior is `Retain`\"\n",
+                  "properties": {
+                    "statefulSet": {
+                      "type": "string",
+                      "description": "Behavior policy for failed StatefulSet, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "pvc": {
+                      "type": "string",
+                      "description": "Behavior policy for failed PVC, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "configMap": {
+                      "type": "string",
+                      "description": "Behavior policy for failed ConfigMap, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "service": {
+                      "type": "string",
+                      "description": "Behavior policy for failed Service, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "defaults": {
+          "type": "object",
+          "description": "define default behavior for whole ClickHouseInstallation, some behavior can be re-define on cluster, shard and replica level\nMore info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specdefaults\n",
+          "properties": {
+            "replicasUseFQDN": {
+              "type": "string",
+              "description": "define should replicas be specified by FQDN in `<host></host>`.\nIn case of \"no\" will use short hostname and clickhouse-server will use kubernetes default suffixes for DNS lookup\n\"no\" by default\n",
+              "enum": [
+                "",
+                "0",
+                "1",
+                "False",
+                "false",
+                "True",
+                "true",
+                "No",
+                "no",
+                "Yes",
+                "yes",
+                "Off",
+                "off",
+                "On",
+                "on",
+                "Disable",
+                "disable",
+                "Enable",
+                "enable",
+                "Disabled",
+                "disabled",
+                "Enabled",
+                "enabled"
+              ]
+            },
+            "distributedDDL": {
+              "type": "object",
+              "description": "allows change `<yandex><distributed_ddl></distributed_ddl></yandex>` settings\nMore info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings-distributed_ddl\n",
+              "properties": {
+                "profile": {
+                  "type": "string",
+                  "description": "Settings from this profile will be used to execute DDL queries"
+                }
+              },
+              "additionalProperties": false
+            },
+            "storageManagement": {
+              "type": "object",
+              "description": "default storage management options",
+              "properties": {
+                "provisioner": {
+                  "type": "string",
+                  "description": "defines `PVC` provisioner - be it StatefulSet or the Operator",
+                  "enum": [
+                    "",
+                    "StatefulSet",
+                    "Operator"
+                  ]
+                },
+                "reclaimPolicy": {
+                  "type": "string",
+                  "description": "defines behavior of `PVC` deletion.\n`Delete` by default, if `Retain` specified then `PVC` will be kept when deleting StatefulSet\n",
+                  "enum": [
+                    "",
+                    "Retain",
+                    "Delete"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
+            "templates": {
+              "type": "object",
+              "description": "optional, configuration of the templates names which will use for generate Kubernetes resources according to one or more ClickHouse clusters described in current ClickHouseInstallation (chi) resource",
+              "properties": {
+                "hostTemplate": {
+                  "type": "string",
+                  "description": "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
+                },
+                "podTemplate": {
+                  "type": "string",
+                  "description": "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                },
+                "dataVolumeClaimTemplate": {
+                  "type": "string",
+                  "description": "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                },
+                "logVolumeClaimTemplate": {
+                  "type": "string",
+                  "description": "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                },
+                "serviceTemplate": {
+                  "type": "string",
+                  "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                },
+                "serviceTemplates": {
+                  "type": "array",
+                  "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                  "nullable": true,
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "clusterServiceTemplate": {
+                  "type": "string",
+                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                },
+                "shardServiceTemplate": {
+                  "type": "string",
+                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
+                },
+                "replicaServiceTemplate": {
+                  "type": "string",
+                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                },
+                "volumeClaimTemplate": {
+                  "type": "string",
+                  "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "configuration": {
+          "type": "object",
+          "description": "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource",
+          "properties": {
+            "settings": {
+              "type": "object",
+              "description": "allows configure multiple aspects and behavior for `clickhouse-keeper` instance\n",
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "files": {
+              "type": "object",
+              "description": "allows define content of any setting\n",
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "clusters": {
+              "type": "array",
+              "description": "describes clusters layout and allows change settings on cluster-level and replica-level\n",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "cluster name, used to identify set of servers and wide used during generate names of related Kubernetes resources",
+                    "minLength": 1,
+                    "maxLength": 15,
+                    "pattern": "^[a-zA-Z0-9-]{0,15}$"
+                  },
+                  "settings": {
+                    "type": "object",
+                    "description": "optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`\noverride top-level `chi.spec.configuration.settings`\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings/\n",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "files": {
+                    "type": "object",
+                    "description": "optional, allows define content of any setting file inside each `Pod` on current cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`\noverride top-level `chi.spec.configuration.files`\n",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "templates": {
+                    "type": "object",
+                    "description": "optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster\noverride top-level `chi.spec.configuration.templates`\n",
+                    "properties": {
+                      "hostTemplate": {
+                        "type": "string",
+                        "description": "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
+                      },
+                      "podTemplate": {
+                        "type": "string",
+                        "description": "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                      },
+                      "dataVolumeClaimTemplate": {
+                        "type": "string",
+                        "description": "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                      },
+                      "logVolumeClaimTemplate": {
+                        "type": "string",
+                        "description": "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                      },
+                      "serviceTemplate": {
+                        "type": "string",
+                        "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                      },
+                      "serviceTemplates": {
+                        "type": "array",
+                        "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                        "nullable": true,
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "clusterServiceTemplate": {
+                        "type": "string",
+                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                      },
+                      "shardServiceTemplate": {
+                        "type": "string",
+                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
+                      },
+                      "replicaServiceTemplate": {
+                        "type": "string",
+                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                      },
+                      "volumeClaimTemplate": {
+                        "type": "string",
+                        "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "pdbManaged": {
+                    "type": "string",
+                    "description": "Specifies whether the Pod Disruption Budget (PDB) should be managed.\nDuring the next installation, if PDB management is enabled, the operator will\nattempt to retrieve any existing PDB. If none is found, it will create a new one\nand initiate a reconciliation loop. If PDB management is disabled, the existing PDB\nwill remain intact, and the reconciliation loop will not be executed. By default,\nPDB management is enabled.\n",
+                    "enum": [
+                      "",
+                      "0",
+                      "1",
+                      "False",
+                      "false",
+                      "True",
+                      "true",
+                      "No",
+                      "no",
+                      "Yes",
+                      "yes",
+                      "Off",
+                      "off",
+                      "On",
+                      "on",
+                      "Disable",
+                      "disable",
+                      "Enable",
+                      "enable",
+                      "Disabled",
+                      "disabled",
+                      "Enabled",
+                      "enabled"
+                    ]
+                  },
+                  "pdbMaxUnavailable": {
+                    "type": "integer",
+                    "description": "Pod eviction is allowed if at most \"pdbMaxUnavailable\" pods are unavailable after the eviction,\ni.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions\nby specifying 0. This is a mutually exclusive setting with \"minAvailable\".\n",
+                    "minimum": 0,
+                    "maximum": 65535
+                  },
+                  "layout": {
+                    "type": "object",
+                    "description": "describe current cluster layout, how much shards in cluster, how much replica in shard\nallows override settings on each shard and replica separatelly\n",
+                    "properties": {
+                      "replicasCount": {
+                        "type": "integer",
+                        "description": "how much replicas in each shards for current cluster will run in Kubernetes,\neach replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,\nevery shard contains 1 replica by default\"\n"
+                      },
+                      "replicas": {
+                        "type": "array",
+                        "description": "optional, allows override top-level `chi.spec.configuration` and cluster-level `chi.spec.configuration.clusters` configuration for each replica and each shard relates to selected replica, use it only if you fully understand what you do",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string",
+                              "description": "optional, by default replica name is generated, but you can override it and setup custom name",
+                              "minLength": 1,
+                              "maxLength": 15,
+                              "pattern": "^[a-zA-Z0-9-]{0,15}$"
+                            },
+                            "settings": {
+                              "type": "object",
+                              "description": "optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`\noverride top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and will ignore if shard-level `chi.spec.configuration.clusters.layout.shards` present\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings/\n",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "files": {
+                              "type": "object",
+                              "description": "optional, allows define content of any setting file inside each `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`\noverride top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents\n",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "templates": {
+                              "type": "object",
+                              "description": "optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica\noverride top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`\n",
+                              "properties": {
+                                "hostTemplate": {
+                                  "type": "string",
+                                  "description": "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
+                                },
+                                "podTemplate": {
+                                  "type": "string",
+                                  "description": "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                                },
+                                "dataVolumeClaimTemplate": {
+                                  "type": "string",
+                                  "description": "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                                },
+                                "logVolumeClaimTemplate": {
+                                  "type": "string",
+                                  "description": "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                                },
+                                "serviceTemplate": {
+                                  "type": "string",
+                                  "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                                },
+                                "serviceTemplates": {
+                                  "type": "array",
+                                  "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                                  "nullable": true,
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "clusterServiceTemplate": {
+                                  "type": "string",
+                                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                                },
+                                "shardServiceTemplate": {
+                                  "type": "string",
+                                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
+                                },
+                                "replicaServiceTemplate": {
+                                  "type": "string",
+                                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                                },
+                                "volumeClaimTemplate": {
+                                  "type": "string",
+                                  "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "shardsCount": {
+                              "type": "integer",
+                              "description": "optional, count of shards related to current replica, you can override each shard behavior on low-level `chi.spec.configuration.clusters.layout.replicas.shards`",
+                              "minimum": 1
+                            },
+                            "shards": {
+                              "type": "array",
+                              "description": "optional, list of shards related to current replica, will ignore if `chi.spec.configuration.clusters.layout.shards` presents",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "optional, by default shard name is generated, but you can override it and setup custom name",
+                                    "minLength": 1,
+                                    "maxLength": 15,
+                                    "pattern": "^[a-zA-Z0-9-]{0,15}$"
+                                  },
+                                  "zkPort": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 65535
+                                  },
+                                  "raftPort": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 65535
+                                  },
+                                  "settings": {
+                                    "type": "object",
+                                    "description": "optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`\noverride top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and replica-level `chi.spec.configuration.clusters.layout.replicas.settings`\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings/\n",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "files": {
+                                    "type": "object",
+                                    "description": "optional, allows define content of any setting file inside each `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`\noverride top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents\n",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "templates": {
+                                    "type": "object",
+                                    "description": "optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica\noverride top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates`\n",
+                                    "properties": {
+                                      "hostTemplate": {
+                                        "type": "string",
+                                        "description": "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
+                                      },
+                                      "podTemplate": {
+                                        "type": "string",
+                                        "description": "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                                      },
+                                      "dataVolumeClaimTemplate": {
+                                        "type": "string",
+                                        "description": "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                                      },
+                                      "logVolumeClaimTemplate": {
+                                        "type": "string",
+                                        "description": "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                                      },
+                                      "serviceTemplate": {
+                                        "type": "string",
+                                        "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                                      },
+                                      "serviceTemplates": {
+                                        "type": "array",
+                                        "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                                        "nullable": true,
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "clusterServiceTemplate": {
+                                        "type": "string",
+                                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                                      },
+                                      "shardServiceTemplate": {
+                                        "type": "string",
+                                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
+                                      },
+                                      "replicaServiceTemplate": {
+                                        "type": "string",
+                                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                                      },
+                                      "volumeClaimTemplate": {
+                                        "type": "string",
+                                        "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "templates": {
+          "type": "object",
+          "description": "allows define templates which will use for render Kubernetes resources like StatefulSet, ConfigMap, Service, PVC, by default, clickhouse-operator have own templates, but you can override it",
+          "properties": {
+            "hostTemplates": {
+              "type": "array",
+              "description": "hostTemplate will use during apply to generate `clickhose-server` config files",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "template name, could use to link inside top-level `chi.spec.defaults.templates.hostTemplate`, cluster-level `chi.spec.configuration.clusters.templates.hostTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.hostTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.hostTemplate`",
+                    "type": "string"
+                  },
+                  "portDistribution": {
+                    "type": "array",
+                    "description": "define how will distribute numeric values of named ports in `Pod.spec.containers.ports` and clickhouse-server configs",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "description": "type of distribution, when `Unspecified` (default value) then all listen ports on clickhouse-server configuration in all Pods will have the same value, when `ClusterScopeIndex` then ports will increment to offset from base value depends on shard and replica index inside cluster with combination of `chi.spec.templates.podTemlates.spec.HostNetwork` it allows setup ClickHouse cluster inside Kubernetes and provide access via external network bypass Kubernetes internal network",
+                          "enum": [
+                            "",
+                            "Unspecified",
+                            "ClusterScopeIndex"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "spec": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "by default, hostname will generate, but this allows define custom name for each `clickhouse-server`",
+                        "minLength": 1,
+                        "maxLength": 15,
+                        "pattern": "^[a-zA-Z0-9-]{0,15}$"
+                      },
+                      "zkPort": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 65535
+                      },
+                      "raftPort": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 65535
+                      },
+                      "settings": {
+                        "type": "object",
+                        "description": "optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings/\n",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "files": {
+                        "type": "object",
+                        "description": "optional, allows define content of any setting file inside each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`\n",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "templates": {
+                        "type": "object",
+                        "description": "be careful, this part of CRD allows override template inside template, don't use it if you don't understand what you do",
+                        "properties": {
+                          "hostTemplate": {
+                            "type": "string",
+                            "description": "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
+                          },
+                          "podTemplate": {
+                            "type": "string",
+                            "description": "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                          },
+                          "dataVolumeClaimTemplate": {
+                            "type": "string",
+                            "description": "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                          },
+                          "logVolumeClaimTemplate": {
+                            "type": "string",
+                            "description": "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                          },
+                          "serviceTemplate": {
+                            "type": "string",
+                            "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                          },
+                          "serviceTemplates": {
+                            "type": "array",
+                            "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                            "nullable": true,
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "clusterServiceTemplate": {
+                            "type": "string",
+                            "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                          },
+                          "shardServiceTemplate": {
+                            "type": "string",
+                            "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
+                          },
+                          "replicaServiceTemplate": {
+                            "type": "string",
+                            "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                          },
+                          "volumeClaimTemplate": {
+                            "type": "string",
+                            "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "podTemplates": {
+              "type": "array",
+              "description": "podTemplate will use during render `Pod` inside `StatefulSet.spec` and allows define rendered `Pod.spec`, pod scheduling distribution and pod zone\nMore information: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatespodtemplates\n",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "template name, could use to link inside top-level `chi.spec.defaults.templates.podTemplate`, cluster-level `chi.spec.configuration.clusters.templates.podTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.podTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.podTemplate`"
+                  },
+                  "generateName": {
+                    "type": "string",
+                    "description": "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about available template variables"
+                  },
+                  "zone": {
+                    "type": "object",
+                    "description": "allows define custom zone name and will separate ClickHouse `Pods` between nodes, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`",
+                    "properties": {
+                      "key": {
+                        "type": "string",
+                        "description": "optional, if defined, allows select kubernetes nodes by label with `name` equal `key`"
+                      },
+                      "values": {
+                        "type": "array",
+                        "description": "optional, if defined, allows select kubernetes nodes by label with `value` in `values`",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "distribution": {
+                    "type": "string",
+                    "description": "DEPRECATED, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`",
+                    "enum": [
+                      "",
+                      "Unspecified",
+                      "OnePerHost"
+                    ]
+                  },
+                  "podDistribution": {
+                    "type": "array",
+                    "description": "define ClickHouse Pod distribution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "description": "you can define multiple affinity policy types",
+                          "enum": [
+                            "",
+                            "Unspecified",
+                            "ClickHouseAntiAffinity",
+                            "ShardAntiAffinity",
+                            "ReplicaAntiAffinity",
+                            "AnotherNamespaceAntiAffinity",
+                            "AnotherClickHouseInstallationAntiAffinity",
+                            "AnotherClusterAntiAffinity",
+                            "MaxNumberPerNode",
+                            "NamespaceAffinity",
+                            "ClickHouseInstallationAffinity",
+                            "ClusterAffinity",
+                            "ShardAffinity",
+                            "ReplicaAffinity",
+                            "PreviousTailAffinity",
+                            "CircularReplication"
+                          ]
+                        },
+                        "scope": {
+                          "type": "string",
+                          "description": "scope for apply each podDistribution",
+                          "enum": [
+                            "",
+                            "Unspecified",
+                            "Shard",
+                            "Replica",
+                            "Cluster",
+                            "ClickHouseInstallation",
+                            "Namespace"
+                          ]
+                        },
+                        "number": {
+                          "type": "integer",
+                          "description": "define, how much ClickHouse Pods could be inside selected scope with selected distribution type",
+                          "minimum": 0,
+                          "maximum": 65535
+                        },
+                        "topologyKey": {
+                          "type": "string",
+                          "description": "use for inter-pod affinity look to `pod.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.topologyKey`,\nmore info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity\"\n"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "description": "allows pass standard object's metadata from template to Pod\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\n",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "spec": {
+                    "type": "object",
+                    "description": "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "volumeClaimTemplates": {
+              "type": "array",
+              "description": "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else\n",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "template name, could use to link inside\ntop-level `chi.spec.defaults.templates.dataVolumeClaimTemplate` or `chi.spec.defaults.templates.logVolumeClaimTemplate`,\ncluster-level `chi.spec.configuration.clusters.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.templates.logVolumeClaimTemplate`,\nshard-level `chi.spec.configuration.clusters.layout.shards.temlates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.shards.temlates.logVolumeClaimTemplate`\nreplica-level `chi.spec.configuration.clusters.layout.replicas.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.replicas.templates.logVolumeClaimTemplate`\n"
+                  },
+                  "provisioner": {
+                    "type": "string",
+                    "description": "defines `PVC` provisioner - be it StatefulSet or the Operator",
+                    "enum": [
+                      "",
+                      "StatefulSet",
+                      "Operator"
+                    ]
+                  },
+                  "reclaimPolicy": {
+                    "type": "string",
+                    "description": "defines behavior of `PVC` deletion.\n`Delete` by default, if `Retain` specified then `PVC` will be kept when deleting StatefulSet\n",
+                    "enum": [
+                      "",
+                      "Retain",
+                      "Delete"
+                    ]
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "description": "allows to pass standard object's metadata from template to PVC\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\n",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "spec": {
+                    "type": "object",
+                    "description": "allows define all aspects of `PVC` resource\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims\n",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "serviceTemplates": {
+              "type": "array",
+              "description": "allows define template for rendering `Service` which would get endpoint from Pods which scoped chi-wide, cluster-wide, shard-wide, replica-wide level\n",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "template name, could use to link inside\nchi-level `chi.spec.defaults.templates.serviceTemplate`\ncluster-level `chi.spec.configuration.clusters.templates.clusterServiceTemplate`\nshard-level `chi.spec.configuration.clusters.layout.shards.temlates.shardServiceTemplate`\nreplica-level `chi.spec.configuration.clusters.layout.replicas.templates.replicaServiceTemplate` or `chi.spec.configuration.clusters.layout.shards.replicas.replicaServiceTemplate`\n"
+                  },
+                  "generateName": {
+                    "type": "string",
+                    "description": "allows define format for generated `Service` name,\nlook to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates\nfor details about available template variables\"\n"
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "description": "allows pass standard object's metadata from template to Service\nCould be use for define specificly for Cloud Provider metadata which impact to behavior of service\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\n",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "spec": {
+                    "type": "object",
+                    "description": "describe behavior of generated Service\nMore info: https://kubernetes.io/docs/concepts/services-networking/service/\n",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/master-standalone-strict/clickhouseoperatorconfiguration-clickhouse-v1.json
+++ b/master-standalone-strict/clickhouseoperatorconfiguration-clickhouse-v1.json
@@ -17,11 +17,9 @@
           "description": "Parameters for watch kubernetes resources which used by clickhouse-operator deployment",
           "properties": {
             "namespaces": {
-              "type": "array",
+              "type": "object",
               "description": "List of namespaces where clickhouse-operator watches for events.",
-              "items": {
-                "type": "string"
-              }
+              "x-kubernetes-preserve-unknown-fields": true
             }
           },
           "additionalProperties": false
@@ -38,18 +36,19 @@
                   "properties": {
                     "path": {
                       "type": "object",
+                      "description": "Each 'path' can be either absolute or relative.\nIn case path is absolute - it is used as is.\nIn case path is relative - it is relative to the folder where configuration file you are reading right now is located.\n",
                       "properties": {
                         "common": {
                           "type": "string",
-                          "description": "Path to the folder where ClickHouse configuration files common for all instances within a CHI are located. Default - config.d"
+                          "description": "Path to the folder where ClickHouse configuration files common for all instances within a CHI are located.\nDefault value - config.d\n"
                         },
                         "host": {
                           "type": "string",
-                          "description": "Path to the folder where ClickHouse configuration files unique for each instance (host) within a CHI are located. Default - conf.d"
+                          "description": "Path to the folder where ClickHouse configuration files unique for each instance (host) within a CHI are located.\nDefault value - conf.d\n"
                         },
                         "user": {
                           "type": "string",
-                          "description": "Path to the folder where ClickHouse configuration files with users settings are located. Files are common for all instances within a CHI. Default - users.d"
+                          "description": "Path to the folder where ClickHouse configuration files with users settings are located.\nFiles are common for all instances within a CHI.\nDefault value - users.d\n"
                         }
                       },
                       "additionalProperties": false
@@ -122,7 +121,8 @@
                         "description": "Set of configuration rules for specified ClickHouse version",
                         "items": {
                           "type": "object",
-                          "description": "setting: value pairs for configuration restart policy"
+                          "description": "setting: value pairs for configuration restart policy",
+                          "x-kubernetes-preserve-unknown-fields": true
                         }
                       }
                     },
@@ -194,6 +194,66 @@
               },
               "additionalProperties": false
             },
+            "addons": {
+              "type": "object",
+              "description": "Configuration addons specifies additional settings",
+              "properties": {
+                "rules": {
+                  "type": "array",
+                  "description": "Array of set of rules per specified ClickHouse versions",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "version": {
+                        "type": "string",
+                        "description": "ClickHouse version expression"
+                      },
+                      "spec": {
+                        "type": "object",
+                        "description": "spec",
+                        "properties": {
+                          "configuration": {
+                            "type": "object",
+                            "description": "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource",
+                            "properties": {
+                              "users": {
+                                "type": "object",
+                                "description": "see same section from CR spec",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              },
+                              "profiles": {
+                                "type": "object",
+                                "description": "see same section from CR spec",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              },
+                              "quotas": {
+                                "type": "object",
+                                "description": "see same section from CR spec",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              },
+                              "settings": {
+                                "type": "object",
+                                "description": "see same section from CR spec",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              },
+                              "files": {
+                                "type": "object",
+                                "description": "see same section from CR spec",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
             "metrics": {
               "type": "object",
               "description": "parameters which use for connect to fetch metrics from clickhouse by clickhouse-operator",
@@ -210,6 +270,10 @@
                     }
                   },
                   "additionalProperties": false
+                },
+                "tablesRegexp": {
+                  "type": "string",
+                  "description": "Regexp to match tables in system database to fetch metrics from.\nMultiple tables can be matched using regexp. Matched tables are merged using merge() table function.\nDefault is \"^(metrics|custom_metrics)$\".\n"
                 }
               },
               "additionalProperties": false
@@ -228,6 +292,7 @@
                   "type": "string",
                   "description": "CHI template updates handling policy\nPossible policy values:\n  - ReadOnStart. Accept CHIT updates on the operators start only.\n  - ApplyOnNextReconcile. Accept CHIT updates at all time. Apply news CHITs on next regular reconcile of the CHI\n",
                   "enum": [
+                    "",
                     "ReadOnStart",
                     "ApplyOnNextReconcile"
                   ]
@@ -301,6 +366,21 @@
                     "onFailure": {
                       "type": "string",
                       "description": "What to do in case updated StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds\nPossible options:\n1. abort - do nothing, just break the process and wait for admin.\n2. rollback (default) - delete Pod and rollback StatefulSet to previous Generation. Pod would be recreated by StatefulSet based on rollback-ed configuration.\n3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet.\n"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "recreate": {
+                  "type": "object",
+                  "description": "Behavior during recreate StatefulSet",
+                  "properties": {
+                    "onDataLoss": {
+                      "type": "string",
+                      "description": "What to do in case operator needs to recreate StatefulSet due to PVC data loss or missing volumes.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet.\n2. recreate (default) - proceed and recreate StatefulSet.\n"
+                    },
+                    "onUpdateFailure": {
+                      "type": "string",
+                      "description": "What to do in case operator needs to recreate StatefulSet due to update failure or StatefulSet not ready.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet.\n2. recreate (default) - proceed and recreate StatefulSet.\n"
                     }
                   },
                   "additionalProperties": false
@@ -401,6 +481,240 @@
                         "Enabled",
                         "enabled"
                       ]
+                    },
+                    "replicas": {
+                      "type": "object",
+                      "description": "Whether the operator during reconcile procedure should wait for replicas to catch-up",
+                      "properties": {
+                        "all": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should wait for all replicas to catch-up",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "new": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should wait for new replicas to catch-up",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "delay": {
+                          "type": "integer",
+                          "description": "replication max absolute delay to consider replica is not delayed"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "probes": {
+                      "type": "object",
+                      "description": "What probes the operator should wait during host launch procedure",
+                      "properties": {
+                        "startup": {
+                          "type": "string",
+                          "description": "Whether the operator during host launch procedure should wait for startup probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to do not wait.\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "readiness": {
+                          "type": "string",
+                          "description": "Whether the operator during host launch procedure should wait for readiness probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to wait.\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "drop": {
+                  "type": "object",
+                  "properties": {
+                    "replicas": {
+                      "type": "object",
+                      "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted or recreated\n",
+                      "properties": {
+                        "onDelete": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "onLostVolume": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop replicas when replica volume is lost\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "active": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop active replicas when replica is deleted or recreated\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
                     }
                   },
                   "additionalProperties": false
@@ -482,6 +796,157 @@
           },
           "additionalProperties": false
         },
+        "metrics": {
+          "type": "object",
+          "description": "defines metrics exporter options",
+          "properties": {
+            "labels": {
+              "type": "object",
+              "description": "defines metric labels options",
+              "properties": {
+                "exclude": {
+                  "type": "array",
+                  "description": "When adding labels to a metric exclude labels with names from the following list\n",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "status": {
+          "type": "object",
+          "description": "defines status options",
+          "properties": {
+            "fields": {
+              "type": "object",
+              "description": "defines status fields options",
+              "properties": {
+                "action": {
+                  "type": "string",
+                  "description": "Whether the operator should fill status field 'action'",
+                  "enum": [
+                    "",
+                    "0",
+                    "1",
+                    "False",
+                    "false",
+                    "True",
+                    "true",
+                    "No",
+                    "no",
+                    "Yes",
+                    "yes",
+                    "Off",
+                    "off",
+                    "On",
+                    "on",
+                    "Disable",
+                    "disable",
+                    "Enable",
+                    "enable",
+                    "Disabled",
+                    "disabled",
+                    "Enabled",
+                    "enabled"
+                  ]
+                },
+                "actions": {
+                  "type": "string",
+                  "description": "Whether the operator should fill status field 'actions'",
+                  "enum": [
+                    "",
+                    "0",
+                    "1",
+                    "False",
+                    "false",
+                    "True",
+                    "true",
+                    "No",
+                    "no",
+                    "Yes",
+                    "yes",
+                    "Off",
+                    "off",
+                    "On",
+                    "on",
+                    "Disable",
+                    "disable",
+                    "Enable",
+                    "enable",
+                    "Disabled",
+                    "disabled",
+                    "Enabled",
+                    "enabled"
+                  ]
+                },
+                "error": {
+                  "type": "string",
+                  "description": "Whether the operator should fill status field 'error'",
+                  "enum": [
+                    "",
+                    "0",
+                    "1",
+                    "False",
+                    "false",
+                    "True",
+                    "true",
+                    "No",
+                    "no",
+                    "Yes",
+                    "yes",
+                    "Off",
+                    "off",
+                    "On",
+                    "on",
+                    "Disable",
+                    "disable",
+                    "Enable",
+                    "enable",
+                    "Disabled",
+                    "disabled",
+                    "Enabled",
+                    "enabled"
+                  ]
+                },
+                "errors": {
+                  "type": "string",
+                  "description": "Whether the operator should fill status field 'errors'",
+                  "enum": [
+                    "",
+                    "0",
+                    "1",
+                    "False",
+                    "false",
+                    "True",
+                    "true",
+                    "No",
+                    "no",
+                    "Yes",
+                    "yes",
+                    "Off",
+                    "off",
+                    "On",
+                    "on",
+                    "Disable",
+                    "disable",
+                    "Enable",
+                    "enable",
+                    "Disabled",
+                    "disabled",
+                    "Enabled",
+                    "enabled"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
         "statefulSet": {
           "type": "object",
           "description": "define StatefulSet-specific parameters",
@@ -534,8 +999,7 @@
           },
           "additionalProperties": false
         }
-      },
-      "additionalProperties": false
+      }
     }
   }
 }

--- a/master-standalone/clickhouseinstallation-clickhouse-v1.json
+++ b/master-standalone/clickhouseinstallation-clickhouse-v1.json
@@ -1,16 +1,16 @@
 {
-  "description": "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters",
+  "description": "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more clusters",
   "type": "object",
   "required": [
     "spec"
   ],
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation\nof an object. Servers should convert recognized schemas to the latest\ninternal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources\n",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this\nobject represents. Servers may infer this from the endpoint the client\nsubmits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds\n",
       "type": "string"
     },
     "metadata": {
@@ -18,23 +18,23 @@
     },
     "status": {
       "type": "object",
-      "description": "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other",
+      "description": "Status contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other\n",
       "properties": {
         "chop-version": {
           "type": "string",
-          "description": "ClickHouse operator version"
+          "description": "Operator version"
         },
         "chop-commit": {
           "type": "string",
-          "description": "ClickHouse operator git commit SHA"
+          "description": "Operator git commit SHA"
         },
         "chop-date": {
           "type": "string",
-          "description": "ClickHouse operator build date"
+          "description": "Operator build date"
         },
         "chop-ip": {
           "type": "string",
-          "description": "IP address of the operator's pod which managed this CHI"
+          "description": "IP address of the operator's pod which managed this resource"
         },
         "clusters": {
           "type": "integer",
@@ -67,6 +67,7 @@
         "taskIDsStarted": {
           "type": "array",
           "description": "Started task ids",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -74,6 +75,7 @@
         "taskIDsCompleted": {
           "type": "array",
           "description": "Completed task ids",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -85,6 +87,7 @@
         "actions": {
           "type": "array",
           "description": "Actions",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -96,9 +99,15 @@
         "errors": {
           "type": "array",
           "description": "Errors",
+          "nullable": true,
           "items": {
             "type": "string"
           }
+        },
+        "hostsUnchanged": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Unchanged Hosts count"
         },
         "hostsUpdated": {
           "type": "integer",
@@ -128,6 +137,7 @@
         "pods": {
           "type": "array",
           "description": "Pods",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -135,6 +145,7 @@
         "pod-ips": {
           "type": "array",
           "description": "Pod IPs",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -142,6 +153,7 @@
         "fqdns": {
           "type": "array",
           "description": "Pods FQDNs",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -150,6 +162,14 @@
           "type": "string",
           "description": "Endpoint"
         },
+        "endpoints": {
+          "type": "array",
+          "description": "All endpoints",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
         "generation": {
           "type": "integer",
           "minimum": 0,
@@ -157,17 +177,34 @@
         },
         "normalized": {
           "type": "object",
-          "description": "Normalized CHI requested",
+          "description": "Normalized resource requested",
+          "nullable": true,
           "x-kubernetes-preserve-unknown-fields": true
         },
         "normalizedCompleted": {
           "type": "object",
-          "description": "Normalized CHI completed",
+          "description": "Normalized resource completed",
+          "nullable": true,
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "actionPlan": {
+          "type": "object",
+          "description": "Action Plan",
+          "nullable": true,
           "x-kubernetes-preserve-unknown-fields": true
         },
         "hostsWithTablesCreated": {
           "type": "array",
           "description": "List of hosts with tables created by the operator",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "hostsWithReplicaCaughtUp": {
+          "type": "array",
+          "description": "List of hosts with replica caught up",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -175,6 +212,7 @@
         "usedTemplates": {
           "type": "array",
           "description": "List of templates used to build this CHI",
+          "nullable": true,
           "x-kubernetes-preserve-unknown-fields": true,
           "items": {
             "type": "object",
@@ -229,6 +267,35 @@
             "RollingUpdate"
           ]
         },
+        "suspend": {
+          "type": "string",
+          "description": "Suspend reconciliation of resources managed by a ClickHouse Installation.\nWorks as the following:\n - When `suspend` is `true` operator stops reconciling all resources.\n - When `suspend` is `false` or not set, operator reconciles all resources.\n",
+          "enum": [
+            "",
+            "0",
+            "1",
+            "False",
+            "false",
+            "True",
+            "true",
+            "No",
+            "no",
+            "Yes",
+            "yes",
+            "Off",
+            "off",
+            "On",
+            "on",
+            "Disable",
+            "disable",
+            "Enable",
+            "enable",
+            "Disabled",
+            "disabled",
+            "Enabled",
+            "enabled"
+          ]
+        },
         "troubleshoot": {
           "type": "string",
           "description": "Allows to troubleshoot Pods during CrashLoopBack state.\nThis may happen when wrong configuration applied, in this case `clickhouse-server` wouldn't start.\nCommand within ClickHouse container is modified with `sleep` in order to avoid quick restarts\nand give time to troubleshoot via CLI.\nLiveness and Readiness probes are disabled as well.\n",
@@ -264,12 +331,13 @@
         },
         "templating": {
           "type": "object",
-          "description": "Optional, defines policy for applying current ClickHouseInstallationTemplate to ClickHouseInstallation(s)",
+          "description": "Optional, applicable inside ClickHouseInstallationTemplate only.\nDefines current ClickHouseInstallationTemplate application options to target ClickHouseInstallation(s).\"\n",
           "properties": {
             "policy": {
               "type": "string",
               "description": "When defined as `auto` inside ClickhouseInstallationTemplate, this ClickhouseInstallationTemplate\nwill be auto-added into ClickHouseInstallation, selectable by `chiSelector`.\nDefault value is `manual`, meaning ClickHouseInstallation should request this ClickhouseInstallationTemplate explicitly.\n",
               "enum": [
+                "",
                 "auto",
                 "manual"
               ]
@@ -284,11 +352,16 @@
         },
         "reconciling": {
           "type": "object",
-          "description": "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side",
+          "description": "[OBSOLETED] Optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side",
           "properties": {
             "policy": {
               "type": "string",
-              "description": "DEPRECATED"
+              "description": "DISCUSSED TO BE DEPRECATED\nSyntax sugar\nOverrides all three 'reconcile.host.wait.{exclude, queries, include}' values from the operator's config\nPossible values:\n - wait - should wait to exclude host, complete queries and include host back into the cluster\n - nowait - should NOT wait to exclude host, complete queries and include host back into the cluster\n",
+              "enum": [
+                "",
+                "wait",
+                "nowait"
+              ]
             },
             "configMapPropagationTimeout": {
               "type": "integer",
@@ -298,40 +371,44 @@
             },
             "cleanup": {
               "type": "object",
-              "description": "optional, define behavior for cleanup Kubernetes resources during reconcile cycle",
+              "description": "Optional, defines behavior for cleanup Kubernetes resources during reconcile cycle",
               "properties": {
                 "unknownObjects": {
                   "type": "object",
-                  "description": "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`",
+                  "description": "Describes what clickhouse-operator should do with found Kubernetes resources which should be managed by clickhouse-operator,\nbut do not have `ownerReference` to any currently managed `ClickHouseInstallation` resource.\nDefault behavior is `Delete`\"\n",
                   "properties": {
                     "statefulSet": {
                       "type": "string",
-                      "description": "behavior policy for unknown StatefulSet, Delete by default",
+                      "description": "Behavior policy for unknown StatefulSet, `Delete` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "pvc": {
                       "type": "string",
-                      "description": "behavior policy for unknown PVC, Delete by default",
+                      "description": "Behavior policy for unknown PVC, `Delete` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "configMap": {
                       "type": "string",
-                      "description": "behavior policy for unknown ConfigMap, Delete by default",
+                      "description": "Behavior policy for unknown ConfigMap, `Delete` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "service": {
                       "type": "string",
-                      "description": "behavior policy for unknown Service, Delete by default",
+                      "description": "Behavior policy for unknown Service, `Delete` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
@@ -341,39 +418,1408 @@
                 },
                 "reconcileFailedObjects": {
                   "type": "object",
-                  "description": "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`",
+                  "description": "Describes what clickhouse-operator should do with Kubernetes resources which are failed during reconcile.\nDefault behavior is `Retain`\"\n",
                   "properties": {
                     "statefulSet": {
                       "type": "string",
-                      "description": "behavior policy for failed StatefulSet reconciling, Retain by default",
+                      "description": "Behavior policy for failed StatefulSet, `Retain` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "pvc": {
                       "type": "string",
-                      "description": "behavior policy for failed PVC reconciling, Retain by default",
+                      "description": "Behavior policy for failed PVC, `Retain` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "configMap": {
                       "type": "string",
-                      "description": "behavior policy for failed ConfigMap reconciling, Retain by default",
+                      "description": "Behavior policy for failed ConfigMap, `Retain` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "service": {
                       "type": "string",
-                      "description": "behavior policy for failed Service reconciling, Retain by default",
+                      "description": "Behavior policy for failed Service, `Retain` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "macros": {
+              "type": "object",
+              "description": "macros parameters",
+              "properties": {
+                "sections": {
+                  "type": "object",
+                  "description": "sections behaviour for macros",
+                  "properties": {
+                    "users": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on users",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "profiles": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on profiles",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "quotas": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on quotas",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "settings": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on settings",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "files": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on files",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "runtime": {
+              "type": "object",
+              "description": "runtime parameters for clickhouse-operator process which are used during reconcile cycle",
+              "properties": {
+                "reconcileShardsThreadsNumber": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535,
+                  "description": "The maximum number of cluster shards that may be reconciled in parallel, 1 by default"
+                },
+                "reconcileShardsMaxConcurrencyPercent": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "The maximum percentage of cluster shards that may be reconciled in parallel, 50 percent by default."
+                }
+              },
+              "additionalProperties": false
+            },
+            "statefulSet": {
+              "type": "object",
+              "description": "Optional, StatefulSet reconcile behavior tuning",
+              "properties": {
+                "create": {
+                  "type": "object",
+                  "description": "Behavior during create StatefulSet",
+                  "properties": {
+                    "onFailure": {
+                      "type": "string",
+                      "description": "What to do in case created StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.\n2. delete - delete newly created problematic StatefulSet and follow 'abort' path afterwards.\n3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "delete",
+                        "ignore"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "update": {
+                  "type": "object",
+                  "description": "Behavior during update StatefulSet",
+                  "properties": {
+                    "timeout": {
+                      "type": "integer",
+                      "description": "How many seconds to wait for StatefulSet to be 'Ready' during update",
+                      "minimum": 0,
+                      "maximum": 3600
+                    },
+                    "pollInterval": {
+                      "type": "integer",
+                      "description": "How many seconds to wait between checks for StatefulSet status during update",
+                      "minimum": 1,
+                      "maximum": 600
+                    },
+                    "onFailure": {
+                      "type": "string",
+                      "description": "What to do in case updated StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.\n2. rollback - delete Pod and rollback StatefulSet to previous Generation. Follow 'abort' path afterwards.\n3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "rollback",
+                        "ignore"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "recreate": {
+                  "type": "object",
+                  "description": "Behavior during recreate StatefulSet",
+                  "properties": {
+                    "onDataLoss": {
+                      "type": "string",
+                      "description": "What to do in case operator needs to recreate StatefulSet due to PVC data loss or missing volumes.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet.\n2. recreate - proceed and recreate StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "recreate"
+                      ]
+                    },
+                    "onUpdateFailure": {
+                      "type": "string",
+                      "description": "What to do in case operator needs to recreate StatefulSet due to update failure or StatefulSet not ready.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet.\n2. recreate - proceed and recreate StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "recreate"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "host": {
+              "type": "object",
+              "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host:\n  - to be excluded from a ClickHouse cluster\n  - to complete all running queries\n  - to be included into a ClickHouse cluster\nrespectfully before moving forward\n",
+              "properties": {
+                "wait": {
+                  "type": "object",
+                  "properties": {
+                    "exclude": {
+                      "type": "string",
+                      "description": "Allows to stop all ClickHouse clusters defined in a CHI.\nWorks as the following:\n - When `stop` is `1` operator sets `Replicas: 0` in each StatefulSet. Thie leads to having all `Pods` and `Service` deleted. All PVCs are kept intact.\n - When `stop` is `0` operator sets `Replicas: 1` and `Pod`s and `Service`s will created again and all retained PVCs will be attached to `Pod`s.\n",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "queries": {
+                      "type": "string",
+                      "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to complete all running queries",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "include": {
+                      "type": "string",
+                      "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to be included into a ClickHouse cluster",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "replicas": {
+                      "type": "object",
+                      "description": "Whether the operator during reconcile procedure should wait for replicas to catch-up",
+                      "properties": {
+                        "all": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should wait for all replicas to catch-up",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "new": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should wait for new replicas to catch-up",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "delay": {
+                          "type": "integer",
+                          "description": "replication max absolute delay to consider replica is not delayed"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "probes": {
+                      "type": "object",
+                      "description": "What probes the operator should wait during host launch procedure",
+                      "properties": {
+                        "startup": {
+                          "type": "string",
+                          "description": "Whether the operator during host launch procedure should wait for startup probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to do not wait.\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "readiness": {
+                          "type": "string",
+                          "description": "Whether the operator during host launch procedure should wait for ready probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to wait.\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "drop": {
+                  "type": "object",
+                  "properties": {
+                    "replicas": {
+                      "type": "object",
+                      "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted or recreated\n",
+                      "properties": {
+                        "onDelete": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "onLostVolume": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop replicas when replica volume is lost\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "active": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop active replicas when replica is deleted or recreated\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "reconcile": {
+          "type": "object",
+          "description": "Optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side",
+          "properties": {
+            "policy": {
+              "type": "string",
+              "description": "DISCUSSED TO BE DEPRECATED\nSyntax sugar\nOverrides all three 'reconcile.host.wait.{exclude, queries, include}' values from the operator's config\nPossible values:\n - wait - should wait to exclude host, complete queries and include host back into the cluster\n - nowait - should NOT wait to exclude host, complete queries and include host back into the cluster\n",
+              "enum": [
+                "",
+                "wait",
+                "nowait"
+              ]
+            },
+            "configMapPropagationTimeout": {
+              "type": "integer",
+              "description": "Timeout in seconds for `clickhouse-operator` to wait for modified `ConfigMap` to propagate into the `Pod`\nMore details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically\n",
+              "minimum": 0,
+              "maximum": 3600
+            },
+            "cleanup": {
+              "type": "object",
+              "description": "Optional, defines behavior for cleanup Kubernetes resources during reconcile cycle",
+              "properties": {
+                "unknownObjects": {
+                  "type": "object",
+                  "description": "Describes what clickhouse-operator should do with found Kubernetes resources which should be managed by clickhouse-operator,\nbut do not have `ownerReference` to any currently managed `ClickHouseInstallation` resource.\nDefault behavior is `Delete`\"\n",
+                  "properties": {
+                    "statefulSet": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown StatefulSet, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "pvc": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown PVC, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "configMap": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown ConfigMap, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "service": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown Service, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "reconcileFailedObjects": {
+                  "type": "object",
+                  "description": "Describes what clickhouse-operator should do with Kubernetes resources which are failed during reconcile.\nDefault behavior is `Retain`\"\n",
+                  "properties": {
+                    "statefulSet": {
+                      "type": "string",
+                      "description": "Behavior policy for failed StatefulSet, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "pvc": {
+                      "type": "string",
+                      "description": "Behavior policy for failed PVC, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "configMap": {
+                      "type": "string",
+                      "description": "Behavior policy for failed ConfigMap, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "service": {
+                      "type": "string",
+                      "description": "Behavior policy for failed Service, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "macros": {
+              "type": "object",
+              "description": "macros parameters",
+              "properties": {
+                "sections": {
+                  "type": "object",
+                  "description": "sections behaviour for macros",
+                  "properties": {
+                    "users": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on users",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "profiles": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on profiles",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "quotas": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on quotas",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "settings": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on settings",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "files": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on files",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "runtime": {
+              "type": "object",
+              "description": "runtime parameters for clickhouse-operator process which are used during reconcile cycle",
+              "properties": {
+                "reconcileShardsThreadsNumber": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535,
+                  "description": "The maximum number of cluster shards that may be reconciled in parallel, 1 by default"
+                },
+                "reconcileShardsMaxConcurrencyPercent": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "The maximum percentage of cluster shards that may be reconciled in parallel, 50 percent by default."
+                }
+              },
+              "additionalProperties": false
+            },
+            "statefulSet": {
+              "type": "object",
+              "description": "Optional, StatefulSet reconcile behavior tuning",
+              "properties": {
+                "create": {
+                  "type": "object",
+                  "description": "Behavior during create StatefulSet",
+                  "properties": {
+                    "onFailure": {
+                      "type": "string",
+                      "description": "What to do in case created StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.\n2. delete - delete newly created problematic StatefulSet and follow 'abort' path afterwards.\n3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "delete",
+                        "ignore"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "update": {
+                  "type": "object",
+                  "description": "Behavior during update StatefulSet",
+                  "properties": {
+                    "timeout": {
+                      "type": "integer",
+                      "description": "How many seconds to wait for StatefulSet to be 'Ready' during update",
+                      "minimum": 0,
+                      "maximum": 3600
+                    },
+                    "pollInterval": {
+                      "type": "integer",
+                      "description": "How many seconds to wait between checks for StatefulSet status during update",
+                      "minimum": 1,
+                      "maximum": 600
+                    },
+                    "onFailure": {
+                      "type": "string",
+                      "description": "What to do in case updated StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.\n2. rollback - delete Pod and rollback StatefulSet to previous Generation. Follow 'abort' path afterwards.\n3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "rollback",
+                        "ignore"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "recreate": {
+                  "type": "object",
+                  "description": "Behavior during recreate StatefulSet",
+                  "properties": {
+                    "onDataLoss": {
+                      "type": "string",
+                      "description": "What to do in case operator needs to recreate StatefulSet due to PVC data loss or missing volumes.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet.\n2. recreate - proceed and recreate StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "recreate"
+                      ]
+                    },
+                    "onUpdateFailure": {
+                      "type": "string",
+                      "description": "What to do in case operator needs to recreate StatefulSet due to update failure or StatefulSet not ready.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet.\n2. recreate - proceed and recreate StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "recreate"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "host": {
+              "type": "object",
+              "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host:\n  - to be excluded from a ClickHouse cluster\n  - to complete all running queries\n  - to be included into a ClickHouse cluster\nrespectfully before moving forward\n",
+              "properties": {
+                "wait": {
+                  "type": "object",
+                  "properties": {
+                    "exclude": {
+                      "type": "string",
+                      "description": "Allows to stop all ClickHouse clusters defined in a CHI.\nWorks as the following:\n - When `stop` is `1` operator sets `Replicas: 0` in each StatefulSet. Thie leads to having all `Pods` and `Service` deleted. All PVCs are kept intact.\n - When `stop` is `0` operator sets `Replicas: 1` and `Pod`s and `Service`s will created again and all retained PVCs will be attached to `Pod`s.\n",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "queries": {
+                      "type": "string",
+                      "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to complete all running queries",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "include": {
+                      "type": "string",
+                      "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to be included into a ClickHouse cluster",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "replicas": {
+                      "type": "object",
+                      "description": "Whether the operator during reconcile procedure should wait for replicas to catch-up",
+                      "properties": {
+                        "all": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should wait for all replicas to catch-up",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "new": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should wait for new replicas to catch-up",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "delay": {
+                          "type": "integer",
+                          "description": "replication max absolute delay to consider replica is not delayed"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "probes": {
+                      "type": "object",
+                      "description": "What probes the operator should wait during host launch procedure",
+                      "properties": {
+                        "startup": {
+                          "type": "string",
+                          "description": "Whether the operator during host launch procedure should wait for startup probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to do not wait.\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "readiness": {
+                          "type": "string",
+                          "description": "Whether the operator during host launch procedure should wait for ready probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to wait.\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "drop": {
+                  "type": "object",
+                  "properties": {
+                    "replicas": {
+                      "type": "object",
+                      "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted or recreated\n",
+                      "properties": {
+                        "onDelete": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "onLostVolume": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop replicas when replica volume is lost\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "active": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop active replicas when replica is deleted or recreated\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
                     }
                   },
                   "additionalProperties": false
@@ -390,7 +1836,7 @@
           "properties": {
             "replicasUseFQDN": {
               "type": "string",
-              "description": "define should replicas be specified by FQDN in `<host></host>`.\nIn case of \"no\" will use short hostname and clickhouse-server will use kubernetes default suffixes for DNS lookup\n\"yes\" by default\n",
+              "description": "define should replicas be specified by FQDN in `<host></host>`.\nIn case of \"no\" will use short hostname and clickhouse-server will use kubernetes default suffixes for DNS lookup\n\"no\" by default\n",
               "enum": [
                 "",
                 "0",
@@ -475,7 +1921,15 @@
                 },
                 "serviceTemplate": {
                   "type": "string",
-                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                  "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                },
+                "serviceTemplates": {
+                  "type": "array",
+                  "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                  "nullable": true,
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "clusterServiceTemplate": {
                   "type": "string",
@@ -491,7 +1945,7 @@
                 },
                 "volumeClaimTemplate": {
                   "type": "string",
-                  "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                  "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                 }
               },
               "additionalProperties": false
@@ -551,6 +2005,10 @@
                           "Enabled",
                           "enabled"
                         ]
+                      },
+                      "availabilityZone": {
+                        "type": "string",
+                        "description": "availability zone for Zookeeper node"
                       }
                     },
                     "additionalProperties": false
@@ -571,13 +2029,42 @@
                 "identity": {
                   "type": "string",
                   "description": "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
+                },
+                "use_compression": {
+                  "type": "string",
+                  "description": "Enables compression in Keeper protocol if set to true",
+                  "enum": [
+                    "",
+                    "0",
+                    "1",
+                    "False",
+                    "false",
+                    "True",
+                    "true",
+                    "No",
+                    "no",
+                    "Yes",
+                    "yes",
+                    "Off",
+                    "off",
+                    "On",
+                    "on",
+                    "Disable",
+                    "disable",
+                    "Enable",
+                    "enable",
+                    "Disabled",
+                    "disabled",
+                    "Enabled",
+                    "enabled"
+                  ]
                 }
               },
               "additionalProperties": false
             },
             "users": {
               "type": "object",
-              "description": "allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`\nyou can configure password hashed, authorization restrictions, database level security row filters etc.\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings-users/\nYour yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers\n",
+              "description": "allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`\nyou can configure password hashed, authorization restrictions, database level security row filters etc.\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings-users/\nYour yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers\n\nany key could contains `valueFrom` with `secretKeyRef` which allow pass password from kubernetes secrets\nsecret value will pass in `pod.spec.containers.evn`, and generate with from_env=XXX in XML in /etc/clickhouse-server/users.d/chop-generated-users.xml\nit not allow automatically updates when updates `secret`, change spec.taskID for manually trigger reconcile cycle\n\nlook into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples\n\nany key with prefix `k8s_secret_` shall has value with format namespace/secret/key or secret/key\nin this case value from secret will write directly into XML tag during render *-usersd ConfigMap\n\nany key with prefix `k8s_secret_env` shall has value with format namespace/secret/key or secret/key\nin this case value from secret will write into environment variable and write to XML tag via from_env=XXX\n\nlook into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples\n",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "profiles": {
@@ -592,23 +2079,23 @@
             },
             "settings": {
               "type": "object",
-              "description": "allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings/\nYour yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings\n",
+              "description": "allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings/\nYour yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings\n\nany key could contains `valueFrom` with `secretKeyRef` which allow pass password from kubernetes secrets\nlook into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples\n\nsecret value will pass in `pod.spec.env`, and generate with from_env=XXX in XML in /etc/clickhouse-server/config.d/chop-generated-settings.xml\nit not allow automatically updates when updates `secret`, change spec.taskID for manually trigger reconcile cycle\n",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "files": {
               "type": "object",
-              "description": "allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`\nevery key in this object is the file name\nevery value in this object is the file content\nyou can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html\neach key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored\nMore details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml\n",
+              "description": "allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`\nevery key in this object is the file name\nevery value in this object is the file content\nyou can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html\neach key could contains prefix like {common}, {users}, {hosts} or config.d, users.d, conf.d, wrong prefixes will be ignored, subfolders also will be ignored\nMore details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml\n\nany key could contains `valueFrom` with `secretKeyRef` which allow pass values from kubernetes secrets\nsecrets will mounted into pod as separate volume in /etc/clickhouse-server/secrets.d/\nand will automatically update when update secret\nit useful for pass SSL certificates from cert-manager or similar tool\nlook into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples\n",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "clusters": {
               "type": "array",
-              "description": "describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level\nevery cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`\nall Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`\nClusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/\nIf `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables\n",
+              "description": "describes clusters layout and allows change settings on cluster-level, shard-level and replica-level\nevery cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`\nall Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`\nClusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/\nIf `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables\n",
               "items": {
                 "type": "object",
                 "properties": {
                   "name": {
                     "type": "string",
-                    "description": "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources",
+                    "description": "cluster name, used to identify set of servers and wide used during generate names of related Kubernetes resources",
                     "minLength": 1,
                     "maxLength": 15,
                     "pattern": "^[a-zA-Z0-9-]{0,15}$"
@@ -661,6 +2148,10 @@
                                 "Enabled",
                                 "enabled"
                               ]
+                            },
+                            "availabilityZone": {
+                              "type": "string",
+                              "description": "availability zone for Zookeeper node"
                             }
                           },
                           "additionalProperties": false
@@ -681,6 +2172,35 @@
                       "identity": {
                         "type": "string",
                         "description": "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
+                      },
+                      "use_compression": {
+                        "type": "string",
+                        "description": "Enables compression in Keeper protocol if set to true",
+                        "enum": [
+                          "",
+                          "0",
+                          "1",
+                          "False",
+                          "false",
+                          "True",
+                          "true",
+                          "No",
+                          "no",
+                          "Yes",
+                          "yes",
+                          "Off",
+                          "off",
+                          "On",
+                          "on",
+                          "Disable",
+                          "disable",
+                          "Enable",
+                          "enable",
+                          "Disabled",
+                          "disabled",
+                          "Enabled",
+                          "enabled"
+                        ]
                       }
                     },
                     "additionalProperties": false
@@ -717,7 +2237,15 @@
                       },
                       "serviceTemplate": {
                         "type": "string",
-                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                        "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                      },
+                      "serviceTemplates": {
+                        "type": "array",
+                        "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                        "nullable": true,
+                        "items": {
+                          "type": "string"
+                        }
                       },
                       "clusterServiceTemplate": {
                         "type": "string",
@@ -733,7 +2261,7 @@
                       },
                       "volumeClaimTemplate": {
                         "type": "string",
-                        "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                        "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                       }
                     },
                     "additionalProperties": false
@@ -746,6 +2274,7 @@
                         "type": "string",
                         "description": "how schema is propagated within a replica",
                         "enum": [
+                          "",
                           "None",
                           "All"
                         ]
@@ -754,6 +2283,7 @@
                         "type": "string",
                         "description": "how schema is propagated between shards",
                         "enum": [
+                          "",
                           "None",
                           "All",
                           "DistributedTablesOnly"
@@ -890,25 +2420,416 @@
                     },
                     "additionalProperties": false
                   },
+                  "pdbManaged": {
+                    "type": "string",
+                    "description": "Specifies whether the Pod Disruption Budget (PDB) should be managed.\nDuring the next installation, if PDB management is enabled, the operator will\nattempt to retrieve any existing PDB. If none is found, it will create a new one\nand initiate a reconciliation loop. If PDB management is disabled, the existing PDB\nwill remain intact, and the reconciliation loop will not be executed. By default,\nPDB management is enabled.\n",
+                    "enum": [
+                      "",
+                      "0",
+                      "1",
+                      "False",
+                      "false",
+                      "True",
+                      "true",
+                      "No",
+                      "no",
+                      "Yes",
+                      "yes",
+                      "Off",
+                      "off",
+                      "On",
+                      "on",
+                      "Disable",
+                      "disable",
+                      "Enable",
+                      "enable",
+                      "Disabled",
+                      "disabled",
+                      "Enabled",
+                      "enabled"
+                    ]
+                  },
+                  "pdbMaxUnavailable": {
+                    "type": "integer",
+                    "description": "Pod eviction is allowed if at most \"pdbMaxUnavailable\" pods are unavailable after the eviction,\ni.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions\nby specifying 0. This is a mutually exclusive setting with \"minAvailable\".\n",
+                    "minimum": 0,
+                    "maximum": 65535
+                  },
+                  "reconcile": {
+                    "type": "object",
+                    "description": "allow tuning reconciling process",
+                    "properties": {
+                      "runtime": {
+                        "type": "object",
+                        "description": "runtime parameters for clickhouse-operator process which are used during reconcile cycle",
+                        "properties": {
+                          "reconcileShardsThreadsNumber": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535,
+                            "description": "The maximum number of cluster shards that may be reconciled in parallel, 1 by default"
+                          },
+                          "reconcileShardsMaxConcurrencyPercent": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 100,
+                            "description": "The maximum percentage of cluster shards that may be reconciled in parallel, 50 percent by default."
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "host": {
+                        "type": "object",
+                        "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host:\n  - to be excluded from a ClickHouse cluster\n  - to complete all running queries\n  - to be included into a ClickHouse cluster\nrespectfully before moving forward\n",
+                        "properties": {
+                          "wait": {
+                            "type": "object",
+                            "properties": {
+                              "exclude": {
+                                "type": "string",
+                                "description": "Allows to stop all ClickHouse clusters defined in a CHI.\nWorks as the following:\n - When `stop` is `1` operator sets `Replicas: 0` in each StatefulSet. Thie leads to having all `Pods` and `Service` deleted. All PVCs are kept intact.\n - When `stop` is `0` operator sets `Replicas: 1` and `Pod`s and `Service`s will created again and all retained PVCs will be attached to `Pod`s.\n",
+                                "enum": [
+                                  "",
+                                  "0",
+                                  "1",
+                                  "False",
+                                  "false",
+                                  "True",
+                                  "true",
+                                  "No",
+                                  "no",
+                                  "Yes",
+                                  "yes",
+                                  "Off",
+                                  "off",
+                                  "On",
+                                  "on",
+                                  "Disable",
+                                  "disable",
+                                  "Enable",
+                                  "enable",
+                                  "Disabled",
+                                  "disabled",
+                                  "Enabled",
+                                  "enabled"
+                                ]
+                              },
+                              "queries": {
+                                "type": "string",
+                                "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to complete all running queries",
+                                "enum": [
+                                  "",
+                                  "0",
+                                  "1",
+                                  "False",
+                                  "false",
+                                  "True",
+                                  "true",
+                                  "No",
+                                  "no",
+                                  "Yes",
+                                  "yes",
+                                  "Off",
+                                  "off",
+                                  "On",
+                                  "on",
+                                  "Disable",
+                                  "disable",
+                                  "Enable",
+                                  "enable",
+                                  "Disabled",
+                                  "disabled",
+                                  "Enabled",
+                                  "enabled"
+                                ]
+                              },
+                              "include": {
+                                "type": "string",
+                                "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to be included into a ClickHouse cluster",
+                                "enum": [
+                                  "",
+                                  "0",
+                                  "1",
+                                  "False",
+                                  "false",
+                                  "True",
+                                  "true",
+                                  "No",
+                                  "no",
+                                  "Yes",
+                                  "yes",
+                                  "Off",
+                                  "off",
+                                  "On",
+                                  "on",
+                                  "Disable",
+                                  "disable",
+                                  "Enable",
+                                  "enable",
+                                  "Disabled",
+                                  "disabled",
+                                  "Enabled",
+                                  "enabled"
+                                ]
+                              },
+                              "replicas": {
+                                "type": "object",
+                                "description": "Whether the operator during reconcile procedure should wait for replicas to catch-up",
+                                "properties": {
+                                  "all": {
+                                    "type": "string",
+                                    "description": "Whether the operator during reconcile procedure should wait for all replicas to catch-up",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  },
+                                  "new": {
+                                    "type": "string",
+                                    "description": "Whether the operator during reconcile procedure should wait for new replicas to catch-up",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  },
+                                  "delay": {
+                                    "type": "integer",
+                                    "description": "replication max absolute delay to consider replica is not delayed"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "probes": {
+                                "type": "object",
+                                "description": "What probes the operator should wait during host launch procedure",
+                                "properties": {
+                                  "startup": {
+                                    "type": "string",
+                                    "description": "Whether the operator during host launch procedure should wait for startup probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to do not wait.\n",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  },
+                                  "readiness": {
+                                    "type": "string",
+                                    "description": "Whether the operator during host launch procedure should wait for ready probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to wait.\n",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "drop": {
+                            "type": "object",
+                            "properties": {
+                              "replicas": {
+                                "type": "object",
+                                "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted or recreated\n",
+                                "properties": {
+                                  "onDelete": {
+                                    "type": "string",
+                                    "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted\n",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  },
+                                  "onLostVolume": {
+                                    "type": "string",
+                                    "description": "Whether the operator during reconcile procedure should drop replicas when replica volume is lost\n",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  },
+                                  "active": {
+                                    "type": "string",
+                                    "description": "Whether the operator during reconcile procedure should drop active replicas when replica is deleted or recreated\n",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  },
                   "layout": {
                     "type": "object",
                     "description": "describe current cluster layout, how much shards in cluster, how much replica in shard\nallows override settings on each shard and replica separatelly\n",
                     "properties": {
-                      "type": {
-                        "type": "string",
-                        "description": "DEPRECATED - to be removed soon"
-                      },
                       "shardsCount": {
                         "type": "integer",
-                        "description": "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
+                        "description": "how much shards for current ClickHouse cluster will run in Kubernetes,\neach shard contains shared-nothing part of data and contains set of replicas,\ncluster contains 1 shard by default\"\n"
                       },
                       "replicasCount": {
                         "type": "integer",
-                        "description": "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
+                        "description": "how much replicas in each shards for current cluster will run in Kubernetes,\neach replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,\nevery shard contains 1 replica by default\"\n"
                       },
                       "shards": {
                         "type": "array",
-                        "description": "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do",
+                        "description": "optional, allows override top-level `chi.spec.configuration`, cluster-level\n`chi.spec.configuration.clusters` settings for each shard separately,\nuse it only if you fully understand what you do\"\n",
                         "items": {
                           "type": "object",
                           "properties": {
@@ -988,7 +2909,15 @@
                                 },
                                 "serviceTemplate": {
                                   "type": "string",
-                                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                                  "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                                },
+                                "serviceTemplates": {
+                                  "type": "array",
+                                  "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                                  "nullable": true,
+                                  "items": {
+                                    "type": "string"
+                                  }
                                 },
                                 "clusterServiceTemplate": {
                                   "type": "string",
@@ -1004,7 +2933,7 @@
                                 },
                                 "volumeClaimTemplate": {
                                   "type": "string",
-                                  "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                                  "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                                 }
                               },
                               "additionalProperties": false
@@ -1145,7 +3074,15 @@
                                       },
                                       "serviceTemplate": {
                                         "type": "string",
-                                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                                        "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                                      },
+                                      "serviceTemplates": {
+                                        "type": "array",
+                                        "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                                        "nullable": true,
+                                        "items": {
+                                          "type": "string"
+                                        }
                                       },
                                       "clusterServiceTemplate": {
                                         "type": "string",
@@ -1161,7 +3098,7 @@
                                       },
                                       "volumeClaimTemplate": {
                                         "type": "string",
-                                        "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                                        "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                                       }
                                     },
                                     "additionalProperties": false
@@ -1219,7 +3156,15 @@
                                 },
                                 "serviceTemplate": {
                                   "type": "string",
-                                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                                  "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                                },
+                                "serviceTemplates": {
+                                  "type": "array",
+                                  "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                                  "nullable": true,
+                                  "items": {
+                                    "type": "string"
+                                  }
                                 },
                                 "clusterServiceTemplate": {
                                   "type": "string",
@@ -1235,7 +3180,7 @@
                                 },
                                 "volumeClaimTemplate": {
                                   "type": "string",
-                                  "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                                  "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                                 }
                               },
                               "additionalProperties": false
@@ -1376,7 +3321,15 @@
                                       },
                                       "serviceTemplate": {
                                         "type": "string",
-                                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                                        "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                                      },
+                                      "serviceTemplates": {
+                                        "type": "array",
+                                        "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                                        "nullable": true,
+                                        "items": {
+                                          "type": "string"
+                                        }
                                       },
                                       "clusterServiceTemplate": {
                                         "type": "string",
@@ -1392,7 +3345,7 @@
                                       },
                                       "volumeClaimTemplate": {
                                         "type": "string",
-                                        "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                                        "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                                       }
                                     },
                                     "additionalProperties": false
@@ -1453,7 +3406,7 @@
                     "properties": {
                       "name": {
                         "type": "string",
-                        "description": "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`",
+                        "description": "by default, hostname will generate, but this allows define custom name for each `clickhouse-server`",
                         "minLength": 1,
                         "maxLength": 15,
                         "pattern": "^[a-zA-Z0-9-]{0,15}$"
@@ -1576,7 +3529,15 @@
                           },
                           "serviceTemplate": {
                             "type": "string",
-                            "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                            "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                          },
+                          "serviceTemplates": {
+                            "type": "array",
+                            "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                            "nullable": true,
+                            "items": {
+                              "type": "string"
+                            }
                           },
                           "clusterServiceTemplate": {
                             "type": "string",
@@ -1592,7 +3553,7 @@
                           },
                           "volumeClaimTemplate": {
                             "type": "string",
-                            "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                            "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                           }
                         },
                         "additionalProperties": false
@@ -1616,7 +3577,7 @@
                   },
                   "generateName": {
                     "type": "string",
-                    "description": "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
+                    "description": "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about available template variables"
                   },
                   "zone": {
                     "type": "object",
@@ -1694,20 +3655,20 @@
                         },
                         "topologyKey": {
                           "type": "string",
-                          "description": "use for inter-pod affinity look to `pod.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.topologyKey`, More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity"
+                          "description": "use for inter-pod affinity look to `pod.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.topologyKey`,\nmore info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity\"\n"
                         }
                       },
                       "additionalProperties": false
                     }
                   },
-                  "spec": {
-                    "type": "object",
-                    "description": "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details",
-                    "x-kubernetes-preserve-unknown-fields": true
-                  },
                   "metadata": {
                     "type": "object",
                     "description": "allows pass standard object's metadata from template to Pod\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\n",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "spec": {
+                    "type": "object",
+                    "description": "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details",
                     "x-kubernetes-preserve-unknown-fields": true
                   }
                 },
@@ -1716,7 +3677,7 @@
             },
             "volumeClaimTemplates": {
               "type": "array",
-              "description": "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else",
+              "description": "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else\n",
               "items": {
                 "type": "object",
                 "properties": {
@@ -1768,11 +3729,11 @@
                   },
                   "generateName": {
                     "type": "string",
-                    "description": "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
+                    "description": "allows define format for generated `Service` name,\nlook to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates\nfor details about available template variables\"\n"
                   },
                   "metadata": {
                     "type": "object",
-                    "description": "allows pass standard object's metadata from template to Service\nCould be use for define specificly for Cloud Provider metadata which impact to behavior of service\nMore info: https://kubernetes.io/docs/concepts/services-networking/service/\n",
+                    "description": "allows pass standard object's metadata from template to Service\nCould be use for define specificly for Cloud Provider metadata which impact to behavior of service\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\n",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
                   "spec": {
@@ -1789,7 +3750,7 @@
         },
         "useTemplates": {
           "type": "array",
-          "description": "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters",
+          "description": "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `CHI`\nmanifest during render Kubernetes resources to create related ClickHouse clusters\"\n",
           "items": {
             "type": "object",
             "properties": {
@@ -1799,7 +3760,7 @@
               },
               "namespace": {
                 "type": "string",
-                "description": "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
+                "description": "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clickhouse-operator`"
               },
               "useType": {
                 "type": "string",

--- a/master-standalone/clickhouseinstallationtemplate-clickhouse-v1.json
+++ b/master-standalone/clickhouseinstallationtemplate-clickhouse-v1.json
@@ -1,16 +1,16 @@
 {
-  "description": "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters",
+  "description": "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more clusters",
   "type": "object",
   "required": [
     "spec"
   ],
   "properties": {
     "apiVersion": {
-      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "description": "APIVersion defines the versioned schema of this representation\nof an object. Servers should convert recognized schemas to the latest\ninternal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources\n",
       "type": "string"
     },
     "kind": {
-      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "description": "Kind is a string value representing the REST resource this\nobject represents. Servers may infer this from the endpoint the client\nsubmits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds\n",
       "type": "string"
     },
     "metadata": {
@@ -18,23 +18,23 @@
     },
     "status": {
       "type": "object",
-      "description": "Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other",
+      "description": "Status contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other\n",
       "properties": {
         "chop-version": {
           "type": "string",
-          "description": "ClickHouse operator version"
+          "description": "Operator version"
         },
         "chop-commit": {
           "type": "string",
-          "description": "ClickHouse operator git commit SHA"
+          "description": "Operator git commit SHA"
         },
         "chop-date": {
           "type": "string",
-          "description": "ClickHouse operator build date"
+          "description": "Operator build date"
         },
         "chop-ip": {
           "type": "string",
-          "description": "IP address of the operator's pod which managed this CHI"
+          "description": "IP address of the operator's pod which managed this resource"
         },
         "clusters": {
           "type": "integer",
@@ -67,6 +67,7 @@
         "taskIDsStarted": {
           "type": "array",
           "description": "Started task ids",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -74,6 +75,7 @@
         "taskIDsCompleted": {
           "type": "array",
           "description": "Completed task ids",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -85,6 +87,7 @@
         "actions": {
           "type": "array",
           "description": "Actions",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -96,9 +99,15 @@
         "errors": {
           "type": "array",
           "description": "Errors",
+          "nullable": true,
           "items": {
             "type": "string"
           }
+        },
+        "hostsUnchanged": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Unchanged Hosts count"
         },
         "hostsUpdated": {
           "type": "integer",
@@ -128,6 +137,7 @@
         "pods": {
           "type": "array",
           "description": "Pods",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -135,6 +145,7 @@
         "pod-ips": {
           "type": "array",
           "description": "Pod IPs",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -142,6 +153,7 @@
         "fqdns": {
           "type": "array",
           "description": "Pods FQDNs",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -150,6 +162,14 @@
           "type": "string",
           "description": "Endpoint"
         },
+        "endpoints": {
+          "type": "array",
+          "description": "All endpoints",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
         "generation": {
           "type": "integer",
           "minimum": 0,
@@ -157,17 +177,34 @@
         },
         "normalized": {
           "type": "object",
-          "description": "Normalized CHI requested",
+          "description": "Normalized resource requested",
+          "nullable": true,
           "x-kubernetes-preserve-unknown-fields": true
         },
         "normalizedCompleted": {
           "type": "object",
-          "description": "Normalized CHI completed",
+          "description": "Normalized resource completed",
+          "nullable": true,
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "actionPlan": {
+          "type": "object",
+          "description": "Action Plan",
+          "nullable": true,
           "x-kubernetes-preserve-unknown-fields": true
         },
         "hostsWithTablesCreated": {
           "type": "array",
           "description": "List of hosts with tables created by the operator",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "hostsWithReplicaCaughtUp": {
+          "type": "array",
+          "description": "List of hosts with replica caught up",
+          "nullable": true,
           "items": {
             "type": "string"
           }
@@ -175,6 +212,7 @@
         "usedTemplates": {
           "type": "array",
           "description": "List of templates used to build this CHI",
+          "nullable": true,
           "x-kubernetes-preserve-unknown-fields": true,
           "items": {
             "type": "object",
@@ -229,6 +267,35 @@
             "RollingUpdate"
           ]
         },
+        "suspend": {
+          "type": "string",
+          "description": "Suspend reconciliation of resources managed by a ClickHouse Installation.\nWorks as the following:\n - When `suspend` is `true` operator stops reconciling all resources.\n - When `suspend` is `false` or not set, operator reconciles all resources.\n",
+          "enum": [
+            "",
+            "0",
+            "1",
+            "False",
+            "false",
+            "True",
+            "true",
+            "No",
+            "no",
+            "Yes",
+            "yes",
+            "Off",
+            "off",
+            "On",
+            "on",
+            "Disable",
+            "disable",
+            "Enable",
+            "enable",
+            "Disabled",
+            "disabled",
+            "Enabled",
+            "enabled"
+          ]
+        },
         "troubleshoot": {
           "type": "string",
           "description": "Allows to troubleshoot Pods during CrashLoopBack state.\nThis may happen when wrong configuration applied, in this case `clickhouse-server` wouldn't start.\nCommand within ClickHouse container is modified with `sleep` in order to avoid quick restarts\nand give time to troubleshoot via CLI.\nLiveness and Readiness probes are disabled as well.\n",
@@ -264,12 +331,13 @@
         },
         "templating": {
           "type": "object",
-          "description": "Optional, defines policy for applying current ClickHouseInstallationTemplate to ClickHouseInstallation(s)",
+          "description": "Optional, applicable inside ClickHouseInstallationTemplate only.\nDefines current ClickHouseInstallationTemplate application options to target ClickHouseInstallation(s).\"\n",
           "properties": {
             "policy": {
               "type": "string",
               "description": "When defined as `auto` inside ClickhouseInstallationTemplate, this ClickhouseInstallationTemplate\nwill be auto-added into ClickHouseInstallation, selectable by `chiSelector`.\nDefault value is `manual`, meaning ClickHouseInstallation should request this ClickhouseInstallationTemplate explicitly.\n",
               "enum": [
+                "",
                 "auto",
                 "manual"
               ]
@@ -284,11 +352,16 @@
         },
         "reconciling": {
           "type": "object",
-          "description": "optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side",
+          "description": "[OBSOLETED] Optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side",
           "properties": {
             "policy": {
               "type": "string",
-              "description": "DEPRECATED"
+              "description": "DISCUSSED TO BE DEPRECATED\nSyntax sugar\nOverrides all three 'reconcile.host.wait.{exclude, queries, include}' values from the operator's config\nPossible values:\n - wait - should wait to exclude host, complete queries and include host back into the cluster\n - nowait - should NOT wait to exclude host, complete queries and include host back into the cluster\n",
+              "enum": [
+                "",
+                "wait",
+                "nowait"
+              ]
             },
             "configMapPropagationTimeout": {
               "type": "integer",
@@ -298,40 +371,44 @@
             },
             "cleanup": {
               "type": "object",
-              "description": "optional, define behavior for cleanup Kubernetes resources during reconcile cycle",
+              "description": "Optional, defines behavior for cleanup Kubernetes resources during reconcile cycle",
               "properties": {
                 "unknownObjects": {
                   "type": "object",
-                  "description": "what clickhouse-operator shall do when found Kubernetes resources which should be managed with clickhouse-operator, but not have `ownerReference` to any currently managed `ClickHouseInstallation` resource, default behavior is `Delete`",
+                  "description": "Describes what clickhouse-operator should do with found Kubernetes resources which should be managed by clickhouse-operator,\nbut do not have `ownerReference` to any currently managed `ClickHouseInstallation` resource.\nDefault behavior is `Delete`\"\n",
                   "properties": {
                     "statefulSet": {
                       "type": "string",
-                      "description": "behavior policy for unknown StatefulSet, Delete by default",
+                      "description": "Behavior policy for unknown StatefulSet, `Delete` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "pvc": {
                       "type": "string",
-                      "description": "behavior policy for unknown PVC, Delete by default",
+                      "description": "Behavior policy for unknown PVC, `Delete` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "configMap": {
                       "type": "string",
-                      "description": "behavior policy for unknown ConfigMap, Delete by default",
+                      "description": "Behavior policy for unknown ConfigMap, `Delete` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "service": {
                       "type": "string",
-                      "description": "behavior policy for unknown Service, Delete by default",
+                      "description": "Behavior policy for unknown Service, `Delete` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
@@ -341,39 +418,1408 @@
                 },
                 "reconcileFailedObjects": {
                   "type": "object",
-                  "description": "what clickhouse-operator shall do when reconciling Kubernetes resources are failed, default behavior is `Retain`",
+                  "description": "Describes what clickhouse-operator should do with Kubernetes resources which are failed during reconcile.\nDefault behavior is `Retain`\"\n",
                   "properties": {
                     "statefulSet": {
                       "type": "string",
-                      "description": "behavior policy for failed StatefulSet reconciling, Retain by default",
+                      "description": "Behavior policy for failed StatefulSet, `Retain` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "pvc": {
                       "type": "string",
-                      "description": "behavior policy for failed PVC reconciling, Retain by default",
+                      "description": "Behavior policy for failed PVC, `Retain` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "configMap": {
                       "type": "string",
-                      "description": "behavior policy for failed ConfigMap reconciling, Retain by default",
+                      "description": "Behavior policy for failed ConfigMap, `Retain` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
                     },
                     "service": {
                       "type": "string",
-                      "description": "behavior policy for failed Service reconciling, Retain by default",
+                      "description": "Behavior policy for failed Service, `Retain` by default",
                       "enum": [
+                        "",
                         "Retain",
                         "Delete"
                       ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "macros": {
+              "type": "object",
+              "description": "macros parameters",
+              "properties": {
+                "sections": {
+                  "type": "object",
+                  "description": "sections behaviour for macros",
+                  "properties": {
+                    "users": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on users",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "profiles": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on profiles",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "quotas": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on quotas",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "settings": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on settings",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "files": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on files",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "runtime": {
+              "type": "object",
+              "description": "runtime parameters for clickhouse-operator process which are used during reconcile cycle",
+              "properties": {
+                "reconcileShardsThreadsNumber": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535,
+                  "description": "The maximum number of cluster shards that may be reconciled in parallel, 1 by default"
+                },
+                "reconcileShardsMaxConcurrencyPercent": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "The maximum percentage of cluster shards that may be reconciled in parallel, 50 percent by default."
+                }
+              },
+              "additionalProperties": false
+            },
+            "statefulSet": {
+              "type": "object",
+              "description": "Optional, StatefulSet reconcile behavior tuning",
+              "properties": {
+                "create": {
+                  "type": "object",
+                  "description": "Behavior during create StatefulSet",
+                  "properties": {
+                    "onFailure": {
+                      "type": "string",
+                      "description": "What to do in case created StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.\n2. delete - delete newly created problematic StatefulSet and follow 'abort' path afterwards.\n3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "delete",
+                        "ignore"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "update": {
+                  "type": "object",
+                  "description": "Behavior during update StatefulSet",
+                  "properties": {
+                    "timeout": {
+                      "type": "integer",
+                      "description": "How many seconds to wait for StatefulSet to be 'Ready' during update",
+                      "minimum": 0,
+                      "maximum": 3600
+                    },
+                    "pollInterval": {
+                      "type": "integer",
+                      "description": "How many seconds to wait between checks for StatefulSet status during update",
+                      "minimum": 1,
+                      "maximum": 600
+                    },
+                    "onFailure": {
+                      "type": "string",
+                      "description": "What to do in case updated StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.\n2. rollback - delete Pod and rollback StatefulSet to previous Generation. Follow 'abort' path afterwards.\n3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "rollback",
+                        "ignore"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "recreate": {
+                  "type": "object",
+                  "description": "Behavior during recreate StatefulSet",
+                  "properties": {
+                    "onDataLoss": {
+                      "type": "string",
+                      "description": "What to do in case operator needs to recreate StatefulSet due to PVC data loss or missing volumes.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet.\n2. recreate - proceed and recreate StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "recreate"
+                      ]
+                    },
+                    "onUpdateFailure": {
+                      "type": "string",
+                      "description": "What to do in case operator needs to recreate StatefulSet due to update failure or StatefulSet not ready.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet.\n2. recreate - proceed and recreate StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "recreate"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "host": {
+              "type": "object",
+              "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host:\n  - to be excluded from a ClickHouse cluster\n  - to complete all running queries\n  - to be included into a ClickHouse cluster\nrespectfully before moving forward\n",
+              "properties": {
+                "wait": {
+                  "type": "object",
+                  "properties": {
+                    "exclude": {
+                      "type": "string",
+                      "description": "Allows to stop all ClickHouse clusters defined in a CHI.\nWorks as the following:\n - When `stop` is `1` operator sets `Replicas: 0` in each StatefulSet. Thie leads to having all `Pods` and `Service` deleted. All PVCs are kept intact.\n - When `stop` is `0` operator sets `Replicas: 1` and `Pod`s and `Service`s will created again and all retained PVCs will be attached to `Pod`s.\n",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "queries": {
+                      "type": "string",
+                      "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to complete all running queries",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "include": {
+                      "type": "string",
+                      "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to be included into a ClickHouse cluster",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "replicas": {
+                      "type": "object",
+                      "description": "Whether the operator during reconcile procedure should wait for replicas to catch-up",
+                      "properties": {
+                        "all": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should wait for all replicas to catch-up",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "new": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should wait for new replicas to catch-up",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "delay": {
+                          "type": "integer",
+                          "description": "replication max absolute delay to consider replica is not delayed"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "probes": {
+                      "type": "object",
+                      "description": "What probes the operator should wait during host launch procedure",
+                      "properties": {
+                        "startup": {
+                          "type": "string",
+                          "description": "Whether the operator during host launch procedure should wait for startup probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to do not wait.\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "readiness": {
+                          "type": "string",
+                          "description": "Whether the operator during host launch procedure should wait for ready probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to wait.\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "drop": {
+                  "type": "object",
+                  "properties": {
+                    "replicas": {
+                      "type": "object",
+                      "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted or recreated\n",
+                      "properties": {
+                        "onDelete": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "onLostVolume": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop replicas when replica volume is lost\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "active": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop active replicas when replica is deleted or recreated\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "reconcile": {
+          "type": "object",
+          "description": "Optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side",
+          "properties": {
+            "policy": {
+              "type": "string",
+              "description": "DISCUSSED TO BE DEPRECATED\nSyntax sugar\nOverrides all three 'reconcile.host.wait.{exclude, queries, include}' values from the operator's config\nPossible values:\n - wait - should wait to exclude host, complete queries and include host back into the cluster\n - nowait - should NOT wait to exclude host, complete queries and include host back into the cluster\n",
+              "enum": [
+                "",
+                "wait",
+                "nowait"
+              ]
+            },
+            "configMapPropagationTimeout": {
+              "type": "integer",
+              "description": "Timeout in seconds for `clickhouse-operator` to wait for modified `ConfigMap` to propagate into the `Pod`\nMore details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically\n",
+              "minimum": 0,
+              "maximum": 3600
+            },
+            "cleanup": {
+              "type": "object",
+              "description": "Optional, defines behavior for cleanup Kubernetes resources during reconcile cycle",
+              "properties": {
+                "unknownObjects": {
+                  "type": "object",
+                  "description": "Describes what clickhouse-operator should do with found Kubernetes resources which should be managed by clickhouse-operator,\nbut do not have `ownerReference` to any currently managed `ClickHouseInstallation` resource.\nDefault behavior is `Delete`\"\n",
+                  "properties": {
+                    "statefulSet": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown StatefulSet, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "pvc": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown PVC, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "configMap": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown ConfigMap, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "service": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown Service, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "reconcileFailedObjects": {
+                  "type": "object",
+                  "description": "Describes what clickhouse-operator should do with Kubernetes resources which are failed during reconcile.\nDefault behavior is `Retain`\"\n",
+                  "properties": {
+                    "statefulSet": {
+                      "type": "string",
+                      "description": "Behavior policy for failed StatefulSet, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "pvc": {
+                      "type": "string",
+                      "description": "Behavior policy for failed PVC, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "configMap": {
+                      "type": "string",
+                      "description": "Behavior policy for failed ConfigMap, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "service": {
+                      "type": "string",
+                      "description": "Behavior policy for failed Service, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "macros": {
+              "type": "object",
+              "description": "macros parameters",
+              "properties": {
+                "sections": {
+                  "type": "object",
+                  "description": "sections behaviour for macros",
+                  "properties": {
+                    "users": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on users",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "profiles": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on profiles",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "quotas": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on quotas",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "settings": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on settings",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "files": {
+                      "type": "object",
+                      "description": "sections behaviour for macros on files",
+                      "properties": {
+                        "enabled": {
+                          "type": "string",
+                          "description": "enabled or not",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "runtime": {
+              "type": "object",
+              "description": "runtime parameters for clickhouse-operator process which are used during reconcile cycle",
+              "properties": {
+                "reconcileShardsThreadsNumber": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 65535,
+                  "description": "The maximum number of cluster shards that may be reconciled in parallel, 1 by default"
+                },
+                "reconcileShardsMaxConcurrencyPercent": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "The maximum percentage of cluster shards that may be reconciled in parallel, 50 percent by default."
+                }
+              },
+              "additionalProperties": false
+            },
+            "statefulSet": {
+              "type": "object",
+              "description": "Optional, StatefulSet reconcile behavior tuning",
+              "properties": {
+                "create": {
+                  "type": "object",
+                  "description": "Behavior during create StatefulSet",
+                  "properties": {
+                    "onFailure": {
+                      "type": "string",
+                      "description": "What to do in case created StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.\n2. delete - delete newly created problematic StatefulSet and follow 'abort' path afterwards.\n3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "delete",
+                        "ignore"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "update": {
+                  "type": "object",
+                  "description": "Behavior during update StatefulSet",
+                  "properties": {
+                    "timeout": {
+                      "type": "integer",
+                      "description": "How many seconds to wait for StatefulSet to be 'Ready' during update",
+                      "minimum": 0,
+                      "maximum": 3600
+                    },
+                    "pollInterval": {
+                      "type": "integer",
+                      "description": "How many seconds to wait between checks for StatefulSet status during update",
+                      "minimum": 1,
+                      "maximum": 600
+                    },
+                    "onFailure": {
+                      "type": "string",
+                      "description": "What to do in case updated StatefulSet is not in 'Ready' after `reconcile.statefulSet.update.timeout` seconds.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet, leave it as it is.\n2. rollback - delete Pod and rollback StatefulSet to previous Generation. Follow 'abort' path afterwards.\n3. ignore - ignore an error, pretend nothing happened, continue reconcile and move on to the next StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "rollback",
+                        "ignore"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "recreate": {
+                  "type": "object",
+                  "description": "Behavior during recreate StatefulSet",
+                  "properties": {
+                    "onDataLoss": {
+                      "type": "string",
+                      "description": "What to do in case operator needs to recreate StatefulSet due to PVC data loss or missing volumes.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet.\n2. recreate - proceed and recreate StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "recreate"
+                      ]
+                    },
+                    "onUpdateFailure": {
+                      "type": "string",
+                      "description": "What to do in case operator needs to recreate StatefulSet due to update failure or StatefulSet not ready.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet.\n2. recreate - proceed and recreate StatefulSet.\n",
+                      "enum": [
+                        "",
+                        "abort",
+                        "recreate"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "host": {
+              "type": "object",
+              "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host:\n  - to be excluded from a ClickHouse cluster\n  - to complete all running queries\n  - to be included into a ClickHouse cluster\nrespectfully before moving forward\n",
+              "properties": {
+                "wait": {
+                  "type": "object",
+                  "properties": {
+                    "exclude": {
+                      "type": "string",
+                      "description": "Allows to stop all ClickHouse clusters defined in a CHI.\nWorks as the following:\n - When `stop` is `1` operator sets `Replicas: 0` in each StatefulSet. Thie leads to having all `Pods` and `Service` deleted. All PVCs are kept intact.\n - When `stop` is `0` operator sets `Replicas: 1` and `Pod`s and `Service`s will created again and all retained PVCs will be attached to `Pod`s.\n",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "queries": {
+                      "type": "string",
+                      "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to complete all running queries",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "include": {
+                      "type": "string",
+                      "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to be included into a ClickHouse cluster",
+                      "enum": [
+                        "",
+                        "0",
+                        "1",
+                        "False",
+                        "false",
+                        "True",
+                        "true",
+                        "No",
+                        "no",
+                        "Yes",
+                        "yes",
+                        "Off",
+                        "off",
+                        "On",
+                        "on",
+                        "Disable",
+                        "disable",
+                        "Enable",
+                        "enable",
+                        "Disabled",
+                        "disabled",
+                        "Enabled",
+                        "enabled"
+                      ]
+                    },
+                    "replicas": {
+                      "type": "object",
+                      "description": "Whether the operator during reconcile procedure should wait for replicas to catch-up",
+                      "properties": {
+                        "all": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should wait for all replicas to catch-up",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "new": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should wait for new replicas to catch-up",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "delay": {
+                          "type": "integer",
+                          "description": "replication max absolute delay to consider replica is not delayed"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "probes": {
+                      "type": "object",
+                      "description": "What probes the operator should wait during host launch procedure",
+                      "properties": {
+                        "startup": {
+                          "type": "string",
+                          "description": "Whether the operator during host launch procedure should wait for startup probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to do not wait.\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "readiness": {
+                          "type": "string",
+                          "description": "Whether the operator during host launch procedure should wait for ready probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to wait.\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "drop": {
+                  "type": "object",
+                  "properties": {
+                    "replicas": {
+                      "type": "object",
+                      "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted or recreated\n",
+                      "properties": {
+                        "onDelete": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "onLostVolume": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop replicas when replica volume is lost\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "active": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop active replicas when replica is deleted or recreated\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
                     }
                   },
                   "additionalProperties": false
@@ -390,7 +1836,7 @@
           "properties": {
             "replicasUseFQDN": {
               "type": "string",
-              "description": "define should replicas be specified by FQDN in `<host></host>`.\nIn case of \"no\" will use short hostname and clickhouse-server will use kubernetes default suffixes for DNS lookup\n\"yes\" by default\n",
+              "description": "define should replicas be specified by FQDN in `<host></host>`.\nIn case of \"no\" will use short hostname and clickhouse-server will use kubernetes default suffixes for DNS lookup\n\"no\" by default\n",
               "enum": [
                 "",
                 "0",
@@ -475,7 +1921,15 @@
                 },
                 "serviceTemplate": {
                   "type": "string",
-                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                  "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                },
+                "serviceTemplates": {
+                  "type": "array",
+                  "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                  "nullable": true,
+                  "items": {
+                    "type": "string"
+                  }
                 },
                 "clusterServiceTemplate": {
                   "type": "string",
@@ -491,7 +1945,7 @@
                 },
                 "volumeClaimTemplate": {
                   "type": "string",
-                  "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                  "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                 }
               },
               "additionalProperties": false
@@ -551,6 +2005,10 @@
                           "Enabled",
                           "enabled"
                         ]
+                      },
+                      "availabilityZone": {
+                        "type": "string",
+                        "description": "availability zone for Zookeeper node"
                       }
                     },
                     "additionalProperties": false
@@ -571,13 +2029,42 @@
                 "identity": {
                   "type": "string",
                   "description": "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
+                },
+                "use_compression": {
+                  "type": "string",
+                  "description": "Enables compression in Keeper protocol if set to true",
+                  "enum": [
+                    "",
+                    "0",
+                    "1",
+                    "False",
+                    "false",
+                    "True",
+                    "true",
+                    "No",
+                    "no",
+                    "Yes",
+                    "yes",
+                    "Off",
+                    "off",
+                    "On",
+                    "on",
+                    "Disable",
+                    "disable",
+                    "Enable",
+                    "enable",
+                    "Disabled",
+                    "disabled",
+                    "Enabled",
+                    "enabled"
+                  ]
                 }
               },
               "additionalProperties": false
             },
             "users": {
               "type": "object",
-              "description": "allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`\nyou can configure password hashed, authorization restrictions, database level security row filters etc.\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings-users/\nYour yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers\n",
+              "description": "allows configure <yandex><users>..</users></yandex> section in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/users.d/`\nyou can configure password hashed, authorization restrictions, database level security row filters etc.\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings-users/\nYour yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationusers\n\nany key could contains `valueFrom` with `secretKeyRef` which allow pass password from kubernetes secrets\nsecret value will pass in `pod.spec.containers.evn`, and generate with from_env=XXX in XML in /etc/clickhouse-server/users.d/chop-generated-users.xml\nit not allow automatically updates when updates `secret`, change spec.taskID for manually trigger reconcile cycle\n\nlook into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples\n\nany key with prefix `k8s_secret_` shall has value with format namespace/secret/key or secret/key\nin this case value from secret will write directly into XML tag during render *-usersd ConfigMap\n\nany key with prefix `k8s_secret_env` shall has value with format namespace/secret/key or secret/key\nin this case value from secret will write into environment variable and write to XML tag via from_env=XXX\n\nlook into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples\n",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "profiles": {
@@ -592,23 +2079,23 @@
             },
             "settings": {
               "type": "object",
-              "description": "allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings/\nYour yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings\n",
+              "description": "allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings/\nYour yaml code will convert to XML, see examples https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specconfigurationsettings\n\nany key could contains `valueFrom` with `secretKeyRef` which allow pass password from kubernetes secrets\nlook into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples\n\nsecret value will pass in `pod.spec.env`, and generate with from_env=XXX in XML in /etc/clickhouse-server/config.d/chop-generated-settings.xml\nit not allow automatically updates when updates `secret`, change spec.taskID for manually trigger reconcile cycle\n",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "files": {
               "type": "object",
-              "description": "allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`\nevery key in this object is the file name\nevery value in this object is the file content\nyou can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html\neach key could contains prefix like USERS, COMMON, HOST or config.d, users.d, cond.d, wrong prefixes will ignored, subfolders also will ignored\nMore details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml\n",
+              "description": "allows define content of any setting file inside each `Pod` during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`\nevery key in this object is the file name\nevery value in this object is the file content\nyou can use `!!binary |` and base64 for binary files, see details here https://yaml.org/type/binary.html\neach key could contains prefix like {common}, {users}, {hosts} or config.d, users.d, conf.d, wrong prefixes will be ignored, subfolders also will be ignored\nMore details: https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-05-files-nested.yaml\n\nany key could contains `valueFrom` with `secretKeyRef` which allow pass values from kubernetes secrets\nsecrets will mounted into pod as separate volume in /etc/clickhouse-server/secrets.d/\nand will automatically update when update secret\nit useful for pass SSL certificates from cert-manager or similar tool\nlook into https://github.com/Altinity/clickhouse-operator/blob/master/docs/chi-examples/05-settings-01-overview.yaml for examples\n",
               "x-kubernetes-preserve-unknown-fields": true
             },
             "clusters": {
               "type": "array",
-              "description": "describes ClickHouse clusters layout and allows change settings on cluster-level, shard-level and replica-level\nevery cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`\nall Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`\nClusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/\nIf `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables\n",
+              "description": "describes clusters layout and allows change settings on cluster-level, shard-level and replica-level\nevery cluster is a set of StatefulSet, one StatefulSet contains only one Pod with `clickhouse-server`\nall Pods will rendered in <remote_server> part of ClickHouse configs, mounted from ConfigMap as `/etc/clickhouse-server/config.d/chop-generated-remote_servers.xml`\nClusters will use for Distributed table engine, more details: https://clickhouse.tech/docs/en/engines/table-engines/special/distributed/\nIf `cluster` contains zookeeper settings (could be inherited from top `chi` level), when you can create *ReplicatedMergeTree tables\n",
               "items": {
                 "type": "object",
                 "properties": {
                   "name": {
                     "type": "string",
-                    "description": "cluster name, used to identify set of ClickHouse servers and wide used during generate names of related Kubernetes resources",
+                    "description": "cluster name, used to identify set of servers and wide used during generate names of related Kubernetes resources",
                     "minLength": 1,
                     "maxLength": 15,
                     "pattern": "^[a-zA-Z0-9-]{0,15}$"
@@ -661,6 +2148,10 @@
                                 "Enabled",
                                 "enabled"
                               ]
+                            },
+                            "availabilityZone": {
+                              "type": "string",
+                              "description": "availability zone for Zookeeper node"
                             }
                           },
                           "additionalProperties": false
@@ -681,6 +2172,35 @@
                       "identity": {
                         "type": "string",
                         "description": "optional access credentials string with `user:password` format used when use digest authorization in Zookeeper"
+                      },
+                      "use_compression": {
+                        "type": "string",
+                        "description": "Enables compression in Keeper protocol if set to true",
+                        "enum": [
+                          "",
+                          "0",
+                          "1",
+                          "False",
+                          "false",
+                          "True",
+                          "true",
+                          "No",
+                          "no",
+                          "Yes",
+                          "yes",
+                          "Off",
+                          "off",
+                          "On",
+                          "on",
+                          "Disable",
+                          "disable",
+                          "Enable",
+                          "enable",
+                          "Disabled",
+                          "disabled",
+                          "Enabled",
+                          "enabled"
+                        ]
                       }
                     },
                     "additionalProperties": false
@@ -717,7 +2237,15 @@
                       },
                       "serviceTemplate": {
                         "type": "string",
-                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                        "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                      },
+                      "serviceTemplates": {
+                        "type": "array",
+                        "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                        "nullable": true,
+                        "items": {
+                          "type": "string"
+                        }
                       },
                       "clusterServiceTemplate": {
                         "type": "string",
@@ -733,7 +2261,7 @@
                       },
                       "volumeClaimTemplate": {
                         "type": "string",
-                        "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                        "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                       }
                     },
                     "additionalProperties": false
@@ -746,6 +2274,7 @@
                         "type": "string",
                         "description": "how schema is propagated within a replica",
                         "enum": [
+                          "",
                           "None",
                           "All"
                         ]
@@ -754,6 +2283,7 @@
                         "type": "string",
                         "description": "how schema is propagated between shards",
                         "enum": [
+                          "",
                           "None",
                           "All",
                           "DistributedTablesOnly"
@@ -890,25 +2420,416 @@
                     },
                     "additionalProperties": false
                   },
+                  "pdbManaged": {
+                    "type": "string",
+                    "description": "Specifies whether the Pod Disruption Budget (PDB) should be managed.\nDuring the next installation, if PDB management is enabled, the operator will\nattempt to retrieve any existing PDB. If none is found, it will create a new one\nand initiate a reconciliation loop. If PDB management is disabled, the existing PDB\nwill remain intact, and the reconciliation loop will not be executed. By default,\nPDB management is enabled.\n",
+                    "enum": [
+                      "",
+                      "0",
+                      "1",
+                      "False",
+                      "false",
+                      "True",
+                      "true",
+                      "No",
+                      "no",
+                      "Yes",
+                      "yes",
+                      "Off",
+                      "off",
+                      "On",
+                      "on",
+                      "Disable",
+                      "disable",
+                      "Enable",
+                      "enable",
+                      "Disabled",
+                      "disabled",
+                      "Enabled",
+                      "enabled"
+                    ]
+                  },
+                  "pdbMaxUnavailable": {
+                    "type": "integer",
+                    "description": "Pod eviction is allowed if at most \"pdbMaxUnavailable\" pods are unavailable after the eviction,\ni.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions\nby specifying 0. This is a mutually exclusive setting with \"minAvailable\".\n",
+                    "minimum": 0,
+                    "maximum": 65535
+                  },
+                  "reconcile": {
+                    "type": "object",
+                    "description": "allow tuning reconciling process",
+                    "properties": {
+                      "runtime": {
+                        "type": "object",
+                        "description": "runtime parameters for clickhouse-operator process which are used during reconcile cycle",
+                        "properties": {
+                          "reconcileShardsThreadsNumber": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 65535,
+                            "description": "The maximum number of cluster shards that may be reconciled in parallel, 1 by default"
+                          },
+                          "reconcileShardsMaxConcurrencyPercent": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 100,
+                            "description": "The maximum percentage of cluster shards that may be reconciled in parallel, 50 percent by default."
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      "host": {
+                        "type": "object",
+                        "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host:\n  - to be excluded from a ClickHouse cluster\n  - to complete all running queries\n  - to be included into a ClickHouse cluster\nrespectfully before moving forward\n",
+                        "properties": {
+                          "wait": {
+                            "type": "object",
+                            "properties": {
+                              "exclude": {
+                                "type": "string",
+                                "description": "Allows to stop all ClickHouse clusters defined in a CHI.\nWorks as the following:\n - When `stop` is `1` operator sets `Replicas: 0` in each StatefulSet. Thie leads to having all `Pods` and `Service` deleted. All PVCs are kept intact.\n - When `stop` is `0` operator sets `Replicas: 1` and `Pod`s and `Service`s will created again and all retained PVCs will be attached to `Pod`s.\n",
+                                "enum": [
+                                  "",
+                                  "0",
+                                  "1",
+                                  "False",
+                                  "false",
+                                  "True",
+                                  "true",
+                                  "No",
+                                  "no",
+                                  "Yes",
+                                  "yes",
+                                  "Off",
+                                  "off",
+                                  "On",
+                                  "on",
+                                  "Disable",
+                                  "disable",
+                                  "Enable",
+                                  "enable",
+                                  "Disabled",
+                                  "disabled",
+                                  "Enabled",
+                                  "enabled"
+                                ]
+                              },
+                              "queries": {
+                                "type": "string",
+                                "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to complete all running queries",
+                                "enum": [
+                                  "",
+                                  "0",
+                                  "1",
+                                  "False",
+                                  "false",
+                                  "True",
+                                  "true",
+                                  "No",
+                                  "no",
+                                  "Yes",
+                                  "yes",
+                                  "Off",
+                                  "off",
+                                  "On",
+                                  "on",
+                                  "Disable",
+                                  "disable",
+                                  "Enable",
+                                  "enable",
+                                  "Disabled",
+                                  "disabled",
+                                  "Enabled",
+                                  "enabled"
+                                ]
+                              },
+                              "include": {
+                                "type": "string",
+                                "description": "Whether the operator during reconcile procedure should wait for a ClickHouse host to be included into a ClickHouse cluster",
+                                "enum": [
+                                  "",
+                                  "0",
+                                  "1",
+                                  "False",
+                                  "false",
+                                  "True",
+                                  "true",
+                                  "No",
+                                  "no",
+                                  "Yes",
+                                  "yes",
+                                  "Off",
+                                  "off",
+                                  "On",
+                                  "on",
+                                  "Disable",
+                                  "disable",
+                                  "Enable",
+                                  "enable",
+                                  "Disabled",
+                                  "disabled",
+                                  "Enabled",
+                                  "enabled"
+                                ]
+                              },
+                              "replicas": {
+                                "type": "object",
+                                "description": "Whether the operator during reconcile procedure should wait for replicas to catch-up",
+                                "properties": {
+                                  "all": {
+                                    "type": "string",
+                                    "description": "Whether the operator during reconcile procedure should wait for all replicas to catch-up",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  },
+                                  "new": {
+                                    "type": "string",
+                                    "description": "Whether the operator during reconcile procedure should wait for new replicas to catch-up",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  },
+                                  "delay": {
+                                    "type": "integer",
+                                    "description": "replication max absolute delay to consider replica is not delayed"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "probes": {
+                                "type": "object",
+                                "description": "What probes the operator should wait during host launch procedure",
+                                "properties": {
+                                  "startup": {
+                                    "type": "string",
+                                    "description": "Whether the operator during host launch procedure should wait for startup probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to do not wait.\n",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  },
+                                  "readiness": {
+                                    "type": "string",
+                                    "description": "Whether the operator during host launch procedure should wait for ready probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to wait.\n",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          "drop": {
+                            "type": "object",
+                            "properties": {
+                              "replicas": {
+                                "type": "object",
+                                "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted or recreated\n",
+                                "properties": {
+                                  "onDelete": {
+                                    "type": "string",
+                                    "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted\n",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  },
+                                  "onLostVolume": {
+                                    "type": "string",
+                                    "description": "Whether the operator during reconcile procedure should drop replicas when replica volume is lost\n",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  },
+                                  "active": {
+                                    "type": "string",
+                                    "description": "Whether the operator during reconcile procedure should drop active replicas when replica is deleted or recreated\n",
+                                    "enum": [
+                                      "",
+                                      "0",
+                                      "1",
+                                      "False",
+                                      "false",
+                                      "True",
+                                      "true",
+                                      "No",
+                                      "no",
+                                      "Yes",
+                                      "yes",
+                                      "Off",
+                                      "off",
+                                      "On",
+                                      "on",
+                                      "Disable",
+                                      "disable",
+                                      "Enable",
+                                      "enable",
+                                      "Disabled",
+                                      "disabled",
+                                      "Enabled",
+                                      "enabled"
+                                    ]
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  },
                   "layout": {
                     "type": "object",
                     "description": "describe current cluster layout, how much shards in cluster, how much replica in shard\nallows override settings on each shard and replica separatelly\n",
                     "properties": {
-                      "type": {
-                        "type": "string",
-                        "description": "DEPRECATED - to be removed soon"
-                      },
                       "shardsCount": {
                         "type": "integer",
-                        "description": "how much shards for current ClickHouse cluster will run in Kubernetes, each shard contains shared-nothing part of data and contains set of replicas, cluster contains 1 shard by default"
+                        "description": "how much shards for current ClickHouse cluster will run in Kubernetes,\neach shard contains shared-nothing part of data and contains set of replicas,\ncluster contains 1 shard by default\"\n"
                       },
                       "replicasCount": {
                         "type": "integer",
-                        "description": "how much replicas in each shards for current ClickHouse cluster will run in Kubernetes, each replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance, every shard contains 1 replica by default"
+                        "description": "how much replicas in each shards for current cluster will run in Kubernetes,\neach replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,\nevery shard contains 1 replica by default\"\n"
                       },
                       "shards": {
                         "type": "array",
-                        "description": "optional, allows override top-level `chi.spec.configuration`, cluster-level `chi.spec.configuration.clusters` settings for each shard separately, use it only if you fully understand what you do",
+                        "description": "optional, allows override top-level `chi.spec.configuration`, cluster-level\n`chi.spec.configuration.clusters` settings for each shard separately,\nuse it only if you fully understand what you do\"\n",
                         "items": {
                           "type": "object",
                           "properties": {
@@ -988,7 +2909,15 @@
                                 },
                                 "serviceTemplate": {
                                   "type": "string",
-                                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                                  "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                                },
+                                "serviceTemplates": {
+                                  "type": "array",
+                                  "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                                  "nullable": true,
+                                  "items": {
+                                    "type": "string"
+                                  }
                                 },
                                 "clusterServiceTemplate": {
                                   "type": "string",
@@ -1004,7 +2933,7 @@
                                 },
                                 "volumeClaimTemplate": {
                                   "type": "string",
-                                  "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                                  "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                                 }
                               },
                               "additionalProperties": false
@@ -1145,7 +3074,15 @@
                                       },
                                       "serviceTemplate": {
                                         "type": "string",
-                                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                                        "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                                      },
+                                      "serviceTemplates": {
+                                        "type": "array",
+                                        "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                                        "nullable": true,
+                                        "items": {
+                                          "type": "string"
+                                        }
                                       },
                                       "clusterServiceTemplate": {
                                         "type": "string",
@@ -1161,7 +3098,7 @@
                                       },
                                       "volumeClaimTemplate": {
                                         "type": "string",
-                                        "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                                        "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                                       }
                                     },
                                     "additionalProperties": false
@@ -1219,7 +3156,15 @@
                                 },
                                 "serviceTemplate": {
                                   "type": "string",
-                                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                                  "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                                },
+                                "serviceTemplates": {
+                                  "type": "array",
+                                  "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                                  "nullable": true,
+                                  "items": {
+                                    "type": "string"
+                                  }
                                 },
                                 "clusterServiceTemplate": {
                                   "type": "string",
@@ -1235,7 +3180,7 @@
                                 },
                                 "volumeClaimTemplate": {
                                   "type": "string",
-                                  "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                                  "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                                 }
                               },
                               "additionalProperties": false
@@ -1376,7 +3321,15 @@
                                       },
                                       "serviceTemplate": {
                                         "type": "string",
-                                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                                        "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                                      },
+                                      "serviceTemplates": {
+                                        "type": "array",
+                                        "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                                        "nullable": true,
+                                        "items": {
+                                          "type": "string"
+                                        }
                                       },
                                       "clusterServiceTemplate": {
                                         "type": "string",
@@ -1392,7 +3345,7 @@
                                       },
                                       "volumeClaimTemplate": {
                                         "type": "string",
-                                        "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                                        "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                                       }
                                     },
                                     "additionalProperties": false
@@ -1453,7 +3406,7 @@
                     "properties": {
                       "name": {
                         "type": "string",
-                        "description": "by default, hostname will generate, but this allows define custom name for each `clickhuse-server`",
+                        "description": "by default, hostname will generate, but this allows define custom name for each `clickhouse-server`",
                         "minLength": 1,
                         "maxLength": 15,
                         "pattern": "^[a-zA-Z0-9-]{0,15}$"
@@ -1576,7 +3529,15 @@
                           },
                           "serviceTemplate": {
                             "type": "string",
-                            "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for one `Service` resource which will created by `clickhouse-operator` which cover all clusters in whole `chi` resource"
+                            "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                          },
+                          "serviceTemplates": {
+                            "type": "array",
+                            "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                            "nullable": true,
+                            "items": {
+                              "type": "string"
+                            }
                           },
                           "clusterServiceTemplate": {
                             "type": "string",
@@ -1592,7 +3553,7 @@
                           },
                           "volumeClaimTemplate": {
                             "type": "string",
-                            "description": "DEPRECATED! VolumeClaimTemplate is deprecated in favor of DataVolumeClaimTemplate and LogVolumeClaimTemplate"
+                            "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
                           }
                         },
                         "additionalProperties": false
@@ -1616,7 +3577,7 @@
                   },
                   "generateName": {
                     "type": "string",
-                    "description": "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
+                    "description": "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about available template variables"
                   },
                   "zone": {
                     "type": "object",
@@ -1694,20 +3655,20 @@
                         },
                         "topologyKey": {
                           "type": "string",
-                          "description": "use for inter-pod affinity look to `pod.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.topologyKey`, More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity"
+                          "description": "use for inter-pod affinity look to `pod.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.topologyKey`,\nmore info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity\"\n"
                         }
                       },
                       "additionalProperties": false
                     }
                   },
-                  "spec": {
-                    "type": "object",
-                    "description": "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details",
-                    "x-kubernetes-preserve-unknown-fields": true
-                  },
                   "metadata": {
                     "type": "object",
                     "description": "allows pass standard object's metadata from template to Pod\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\n",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "spec": {
+                    "type": "object",
+                    "description": "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details",
                     "x-kubernetes-preserve-unknown-fields": true
                   }
                 },
@@ -1716,7 +3677,7 @@
             },
             "volumeClaimTemplates": {
               "type": "array",
-              "description": "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else",
+              "description": "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else\n",
               "items": {
                 "type": "object",
                 "properties": {
@@ -1768,11 +3729,11 @@
                   },
                   "generateName": {
                     "type": "string",
-                    "description": "allows define format for generated `Service` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about aviailable template variables"
+                    "description": "allows define format for generated `Service` name,\nlook to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates\nfor details about available template variables\"\n"
                   },
                   "metadata": {
                     "type": "object",
-                    "description": "allows pass standard object's metadata from template to Service\nCould be use for define specificly for Cloud Provider metadata which impact to behavior of service\nMore info: https://kubernetes.io/docs/concepts/services-networking/service/\n",
+                    "description": "allows pass standard object's metadata from template to Service\nCould be use for define specificly for Cloud Provider metadata which impact to behavior of service\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\n",
                     "x-kubernetes-preserve-unknown-fields": true
                   },
                   "spec": {
@@ -1789,7 +3750,7 @@
         },
         "useTemplates": {
           "type": "array",
-          "description": "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `Chi` manifest during render Kubernetes resources to create related ClickHouse clusters",
+          "description": "list of `ClickHouseInstallationTemplate` (chit) resource names which will merge with current `CHI`\nmanifest during render Kubernetes resources to create related ClickHouse clusters\"\n",
           "items": {
             "type": "object",
             "properties": {
@@ -1799,7 +3760,7 @@
               },
               "namespace": {
                 "type": "string",
-                "description": "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clichouse-operator`"
+                "description": "Kubernetes namespace where need search `chit` resource, depending on `watchNamespaces` settings in `clickhouse-operator`"
               },
               "useType": {
                 "type": "string",

--- a/master-standalone/clickhousekeeperinstallation-clickhouse-keeper-v1.json
+++ b/master-standalone/clickhousekeeperinstallation-clickhouse-keeper-v1.json
@@ -1,0 +1,1147 @@
+{
+  "description": "define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more clusters",
+  "type": "object",
+  "required": [
+    "spec"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation\nof an object. Servers should convert recognized schemas to the latest\ninternal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources\n",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this\nobject represents. Servers may infer this from the endpoint the client\nsubmits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds\n",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "status": {
+      "type": "object",
+      "description": "Status contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other\n",
+      "properties": {
+        "chop-version": {
+          "type": "string",
+          "description": "Operator version"
+        },
+        "chop-commit": {
+          "type": "string",
+          "description": "Operator git commit SHA"
+        },
+        "chop-date": {
+          "type": "string",
+          "description": "Operator build date"
+        },
+        "chop-ip": {
+          "type": "string",
+          "description": "IP address of the operator's pod which managed this resource"
+        },
+        "clusters": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Clusters count"
+        },
+        "shards": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Shards count"
+        },
+        "replicas": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Replicas count"
+        },
+        "hosts": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Hosts count"
+        },
+        "status": {
+          "type": "string",
+          "description": "Status"
+        },
+        "taskID": {
+          "type": "string",
+          "description": "Current task id"
+        },
+        "taskIDsStarted": {
+          "type": "array",
+          "description": "Started task ids",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "taskIDsCompleted": {
+          "type": "array",
+          "description": "Completed task ids",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "action": {
+          "type": "string",
+          "description": "Action"
+        },
+        "actions": {
+          "type": "array",
+          "description": "Actions",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "error": {
+          "type": "string",
+          "description": "Last error"
+        },
+        "errors": {
+          "type": "array",
+          "description": "Errors",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "hostsUnchanged": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Unchanged Hosts count"
+        },
+        "hostsUpdated": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Updated Hosts count"
+        },
+        "hostsAdded": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Added Hosts count"
+        },
+        "hostsCompleted": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Completed Hosts count"
+        },
+        "hostsDeleted": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Deleted Hosts count"
+        },
+        "hostsDelete": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "About to delete Hosts count"
+        },
+        "pods": {
+          "type": "array",
+          "description": "Pods",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "pod-ips": {
+          "type": "array",
+          "description": "Pod IPs",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "fqdns": {
+          "type": "array",
+          "description": "Pods FQDNs",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "Endpoint"
+        },
+        "endpoints": {
+          "type": "array",
+          "description": "All endpoints",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "generation": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Generation"
+        },
+        "normalized": {
+          "type": "object",
+          "description": "Normalized resource requested",
+          "nullable": true,
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "normalizedCompleted": {
+          "type": "object",
+          "description": "Normalized resource completed",
+          "nullable": true,
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "hostsWithTablesCreated": {
+          "type": "array",
+          "description": "List of hosts with tables created by the operator",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "hostsWithReplicaCaughtUp": {
+          "type": "array",
+          "description": "List of hosts with replica caught up",
+          "nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "usedTemplates": {
+          "type": "array",
+          "description": "List of templates used to build this CHI",
+          "nullable": true,
+          "x-kubernetes-preserve-unknown-fields": true,
+          "items": {
+            "type": "object",
+            "x-kubernetes-preserve-unknown-fields": true
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "spec": {
+      "type": "object",
+      "description": "Specification of the desired behavior of one or more ClickHouse clusters\nMore info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md\n",
+      "properties": {
+        "taskID": {
+          "type": "string",
+          "description": "Allows to define custom taskID for CHI update and watch status of this update execution.\nDisplayed in all .status.taskID* fields.\nBy default (if not filled) every update of CHI manifest will generate random taskID\n"
+        },
+        "stop": {
+          "type": "string",
+          "description": "Allows to stop all ClickHouse Keeper clusters defined in a CHK.\nWorks as the following:\n - When `stop` is `1` operator sets `Replicas: 0` in each StatefulSet. Thie leads to having all `Pods` and `Service` deleted. All PVCs are kept intact.\n - When `stop` is `0` operator sets `Replicas: 1` and `Pod`s and `Service`s will created again and all retained PVCs will be attached to `Pod`s.\n",
+          "enum": [
+            "",
+            "0",
+            "1",
+            "False",
+            "false",
+            "True",
+            "true",
+            "No",
+            "no",
+            "Yes",
+            "yes",
+            "Off",
+            "off",
+            "On",
+            "on",
+            "Disable",
+            "disable",
+            "Enable",
+            "enable",
+            "Disabled",
+            "disabled",
+            "Enabled",
+            "enabled"
+          ]
+        },
+        "suspend": {
+          "type": "string",
+          "description": "Suspend reconciliation of resources managed by a ClickHouse Keeper.\nWorks as the following:\n - When `suspend` is `true` operator stops reconciling all resources.\n - When `suspend` is `false` or not set, operator reconciles all resources.\n",
+          "enum": [
+            "",
+            "0",
+            "1",
+            "False",
+            "false",
+            "True",
+            "true",
+            "No",
+            "no",
+            "Yes",
+            "yes",
+            "Off",
+            "off",
+            "On",
+            "on",
+            "Disable",
+            "disable",
+            "Enable",
+            "enable",
+            "Disabled",
+            "disabled",
+            "Enabled",
+            "enabled"
+          ]
+        },
+        "namespaceDomainPattern": {
+          "type": "string",
+          "description": "Custom domain pattern which will be used for DNS names of `Service` or `Pod`.\nTypical use scenario - custom cluster domain in Kubernetes cluster\nExample: %s.svc.my.test\n"
+        },
+        "reconciling": {
+          "type": "object",
+          "description": "Optional, allows tuning reconciling cycle for ClickhouseInstallation from clickhouse-operator side",
+          "properties": {
+            "policy": {
+              "type": "string",
+              "description": "DISCUSSED TO BE DEPRECATED\nSyntax sugar\nOverrides all three 'reconcile.host.wait.{exclude, queries, include}' values from the operator's config\nPossible values:\n - wait - should wait to exclude host, complete queries and include host back into the cluster\n - nowait - should NOT wait to exclude host, complete queries and include host back into the cluster\n",
+              "enum": [
+                "",
+                "wait",
+                "nowait"
+              ]
+            },
+            "configMapPropagationTimeout": {
+              "type": "integer",
+              "description": "Timeout in seconds for `clickhouse-operator` to wait for modified `ConfigMap` to propagate into the `Pod`\nMore details: https://kubernetes.io/docs/concepts/configuration/configmap/#mounted-configmaps-are-updated-automatically\n",
+              "minimum": 0,
+              "maximum": 3600
+            },
+            "cleanup": {
+              "type": "object",
+              "description": "Optional, defines behavior for cleanup Kubernetes resources during reconcile cycle",
+              "properties": {
+                "unknownObjects": {
+                  "type": "object",
+                  "description": "Describes what clickhouse-operator should do with found Kubernetes resources which should be managed by clickhouse-operator,\nbut do not have `ownerReference` to any currently managed `ClickHouseInstallation` resource.\nDefault behavior is `Delete`\"\n",
+                  "properties": {
+                    "statefulSet": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown StatefulSet, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "pvc": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown PVC, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "configMap": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown ConfigMap, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "service": {
+                      "type": "string",
+                      "description": "Behavior policy for unknown Service, `Delete` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "reconcileFailedObjects": {
+                  "type": "object",
+                  "description": "Describes what clickhouse-operator should do with Kubernetes resources which are failed during reconcile.\nDefault behavior is `Retain`\"\n",
+                  "properties": {
+                    "statefulSet": {
+                      "type": "string",
+                      "description": "Behavior policy for failed StatefulSet, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "pvc": {
+                      "type": "string",
+                      "description": "Behavior policy for failed PVC, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "configMap": {
+                      "type": "string",
+                      "description": "Behavior policy for failed ConfigMap, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    },
+                    "service": {
+                      "type": "string",
+                      "description": "Behavior policy for failed Service, `Retain` by default",
+                      "enum": [
+                        "",
+                        "Retain",
+                        "Delete"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "defaults": {
+          "type": "object",
+          "description": "define default behavior for whole ClickHouseInstallation, some behavior can be re-define on cluster, shard and replica level\nMore info: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#specdefaults\n",
+          "properties": {
+            "replicasUseFQDN": {
+              "type": "string",
+              "description": "define should replicas be specified by FQDN in `<host></host>`.\nIn case of \"no\" will use short hostname and clickhouse-server will use kubernetes default suffixes for DNS lookup\n\"no\" by default\n",
+              "enum": [
+                "",
+                "0",
+                "1",
+                "False",
+                "false",
+                "True",
+                "true",
+                "No",
+                "no",
+                "Yes",
+                "yes",
+                "Off",
+                "off",
+                "On",
+                "on",
+                "Disable",
+                "disable",
+                "Enable",
+                "enable",
+                "Disabled",
+                "disabled",
+                "Enabled",
+                "enabled"
+              ]
+            },
+            "distributedDDL": {
+              "type": "object",
+              "description": "allows change `<yandex><distributed_ddl></distributed_ddl></yandex>` settings\nMore info: https://clickhouse.tech/docs/en/operations/server-configuration-parameters/settings/#server-settings-distributed_ddl\n",
+              "properties": {
+                "profile": {
+                  "type": "string",
+                  "description": "Settings from this profile will be used to execute DDL queries"
+                }
+              },
+              "additionalProperties": false
+            },
+            "storageManagement": {
+              "type": "object",
+              "description": "default storage management options",
+              "properties": {
+                "provisioner": {
+                  "type": "string",
+                  "description": "defines `PVC` provisioner - be it StatefulSet or the Operator",
+                  "enum": [
+                    "",
+                    "StatefulSet",
+                    "Operator"
+                  ]
+                },
+                "reclaimPolicy": {
+                  "type": "string",
+                  "description": "defines behavior of `PVC` deletion.\n`Delete` by default, if `Retain` specified then `PVC` will be kept when deleting StatefulSet\n",
+                  "enum": [
+                    "",
+                    "Retain",
+                    "Delete"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            },
+            "templates": {
+              "type": "object",
+              "description": "optional, configuration of the templates names which will use for generate Kubernetes resources according to one or more ClickHouse clusters described in current ClickHouseInstallation (chi) resource",
+              "properties": {
+                "hostTemplate": {
+                  "type": "string",
+                  "description": "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
+                },
+                "podTemplate": {
+                  "type": "string",
+                  "description": "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                },
+                "dataVolumeClaimTemplate": {
+                  "type": "string",
+                  "description": "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                },
+                "logVolumeClaimTemplate": {
+                  "type": "string",
+                  "description": "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                },
+                "serviceTemplate": {
+                  "type": "string",
+                  "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                },
+                "serviceTemplates": {
+                  "type": "array",
+                  "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                  "nullable": true,
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "clusterServiceTemplate": {
+                  "type": "string",
+                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                },
+                "shardServiceTemplate": {
+                  "type": "string",
+                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
+                },
+                "replicaServiceTemplate": {
+                  "type": "string",
+                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                },
+                "volumeClaimTemplate": {
+                  "type": "string",
+                  "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "configuration": {
+          "type": "object",
+          "description": "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource",
+          "properties": {
+            "settings": {
+              "type": "object",
+              "description": "allows configure multiple aspects and behavior for `clickhouse-keeper` instance\n",
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "files": {
+              "type": "object",
+              "description": "allows define content of any setting\n",
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "clusters": {
+              "type": "array",
+              "description": "describes clusters layout and allows change settings on cluster-level and replica-level\n",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "cluster name, used to identify set of servers and wide used during generate names of related Kubernetes resources",
+                    "minLength": 1,
+                    "maxLength": 15,
+                    "pattern": "^[a-zA-Z0-9-]{0,15}$"
+                  },
+                  "settings": {
+                    "type": "object",
+                    "description": "optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` only in one cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/`\noverride top-level `chi.spec.configuration.settings`\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings/\n",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "files": {
+                    "type": "object",
+                    "description": "optional, allows define content of any setting file inside each `Pod` on current cluster during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`\noverride top-level `chi.spec.configuration.files`\n",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "templates": {
+                    "type": "object",
+                    "description": "optional, configuration of the templates names which will use for generate Kubernetes resources according to selected cluster\noverride top-level `chi.spec.configuration.templates`\n",
+                    "properties": {
+                      "hostTemplate": {
+                        "type": "string",
+                        "description": "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
+                      },
+                      "podTemplate": {
+                        "type": "string",
+                        "description": "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                      },
+                      "dataVolumeClaimTemplate": {
+                        "type": "string",
+                        "description": "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                      },
+                      "logVolumeClaimTemplate": {
+                        "type": "string",
+                        "description": "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                      },
+                      "serviceTemplate": {
+                        "type": "string",
+                        "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                      },
+                      "serviceTemplates": {
+                        "type": "array",
+                        "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                        "nullable": true,
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "clusterServiceTemplate": {
+                        "type": "string",
+                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                      },
+                      "shardServiceTemplate": {
+                        "type": "string",
+                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
+                      },
+                      "replicaServiceTemplate": {
+                        "type": "string",
+                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                      },
+                      "volumeClaimTemplate": {
+                        "type": "string",
+                        "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "pdbManaged": {
+                    "type": "string",
+                    "description": "Specifies whether the Pod Disruption Budget (PDB) should be managed.\nDuring the next installation, if PDB management is enabled, the operator will\nattempt to retrieve any existing PDB. If none is found, it will create a new one\nand initiate a reconciliation loop. If PDB management is disabled, the existing PDB\nwill remain intact, and the reconciliation loop will not be executed. By default,\nPDB management is enabled.\n",
+                    "enum": [
+                      "",
+                      "0",
+                      "1",
+                      "False",
+                      "false",
+                      "True",
+                      "true",
+                      "No",
+                      "no",
+                      "Yes",
+                      "yes",
+                      "Off",
+                      "off",
+                      "On",
+                      "on",
+                      "Disable",
+                      "disable",
+                      "Enable",
+                      "enable",
+                      "Disabled",
+                      "disabled",
+                      "Enabled",
+                      "enabled"
+                    ]
+                  },
+                  "pdbMaxUnavailable": {
+                    "type": "integer",
+                    "description": "Pod eviction is allowed if at most \"pdbMaxUnavailable\" pods are unavailable after the eviction,\ni.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions\nby specifying 0. This is a mutually exclusive setting with \"minAvailable\".\n",
+                    "minimum": 0,
+                    "maximum": 65535
+                  },
+                  "layout": {
+                    "type": "object",
+                    "description": "describe current cluster layout, how much shards in cluster, how much replica in shard\nallows override settings on each shard and replica separatelly\n",
+                    "properties": {
+                      "replicasCount": {
+                        "type": "integer",
+                        "description": "how much replicas in each shards for current cluster will run in Kubernetes,\neach replica is a separate `StatefulSet` which contains only one `Pod` with `clickhouse-server` instance,\nevery shard contains 1 replica by default\"\n"
+                      },
+                      "replicas": {
+                        "type": "array",
+                        "description": "optional, allows override top-level `chi.spec.configuration` and cluster-level `chi.spec.configuration.clusters` configuration for each replica and each shard relates to selected replica, use it only if you fully understand what you do",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string",
+                              "description": "optional, by default replica name is generated, but you can override it and setup custom name",
+                              "minLength": 1,
+                              "maxLength": 15,
+                              "pattern": "^[a-zA-Z0-9-]{0,15}$"
+                            },
+                            "settings": {
+                              "type": "object",
+                              "description": "optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`\noverride top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and will ignore if shard-level `chi.spec.configuration.clusters.layout.shards` present\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings/\n",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "files": {
+                              "type": "object",
+                              "description": "optional, allows define content of any setting file inside each `Pod` only in one replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`\noverride top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents\n",
+                              "x-kubernetes-preserve-unknown-fields": true
+                            },
+                            "templates": {
+                              "type": "object",
+                              "description": "optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica\noverride top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`\n",
+                              "properties": {
+                                "hostTemplate": {
+                                  "type": "string",
+                                  "description": "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
+                                },
+                                "podTemplate": {
+                                  "type": "string",
+                                  "description": "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                                },
+                                "dataVolumeClaimTemplate": {
+                                  "type": "string",
+                                  "description": "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                                },
+                                "logVolumeClaimTemplate": {
+                                  "type": "string",
+                                  "description": "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                                },
+                                "serviceTemplate": {
+                                  "type": "string",
+                                  "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                                },
+                                "serviceTemplates": {
+                                  "type": "array",
+                                  "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                                  "nullable": true,
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "clusterServiceTemplate": {
+                                  "type": "string",
+                                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                                },
+                                "shardServiceTemplate": {
+                                  "type": "string",
+                                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
+                                },
+                                "replicaServiceTemplate": {
+                                  "type": "string",
+                                  "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                                },
+                                "volumeClaimTemplate": {
+                                  "type": "string",
+                                  "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "shardsCount": {
+                              "type": "integer",
+                              "description": "optional, count of shards related to current replica, you can override each shard behavior on low-level `chi.spec.configuration.clusters.layout.replicas.shards`",
+                              "minimum": 1
+                            },
+                            "shards": {
+                              "type": "array",
+                              "description": "optional, list of shards related to current replica, will ignore if `chi.spec.configuration.clusters.layout.shards` presents",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                    "description": "optional, by default shard name is generated, but you can override it and setup custom name",
+                                    "minLength": 1,
+                                    "maxLength": 15,
+                                    "pattern": "^[a-zA-Z0-9-]{0,15}$"
+                                  },
+                                  "zkPort": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 65535
+                                  },
+                                  "raftPort": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 65535
+                                  },
+                                  "settings": {
+                                    "type": "object",
+                                    "description": "optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`\noverride top-level `chi.spec.configuration.settings`, cluster-level `chi.spec.configuration.clusters.settings` and replica-level `chi.spec.configuration.clusters.layout.replicas.settings`\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings/\n",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "files": {
+                                    "type": "object",
+                                    "description": "optional, allows define content of any setting file inside each `Pod` only in one shard related to current replica during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`\noverride top-level `chi.spec.configuration.files` and cluster-level `chi.spec.configuration.clusters.files`, will ignore if `chi.spec.configuration.clusters.layout.shards` presents\n",
+                                    "x-kubernetes-preserve-unknown-fields": true
+                                  },
+                                  "templates": {
+                                    "type": "object",
+                                    "description": "optional, configuration of the templates names which will use for generate Kubernetes resources according to selected replica\noverride top-level `chi.spec.configuration.templates`, cluster-level `chi.spec.configuration.clusters.templates`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates`\n",
+                                    "properties": {
+                                      "hostTemplate": {
+                                        "type": "string",
+                                        "description": "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
+                                      },
+                                      "podTemplate": {
+                                        "type": "string",
+                                        "description": "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                                      },
+                                      "dataVolumeClaimTemplate": {
+                                        "type": "string",
+                                        "description": "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                                      },
+                                      "logVolumeClaimTemplate": {
+                                        "type": "string",
+                                        "description": "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                                      },
+                                      "serviceTemplate": {
+                                        "type": "string",
+                                        "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                                      },
+                                      "serviceTemplates": {
+                                        "type": "array",
+                                        "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                                        "nullable": true,
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "clusterServiceTemplate": {
+                                        "type": "string",
+                                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                                      },
+                                      "shardServiceTemplate": {
+                                        "type": "string",
+                                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
+                                      },
+                                      "replicaServiceTemplate": {
+                                        "type": "string",
+                                        "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                                      },
+                                      "volumeClaimTemplate": {
+                                        "type": "string",
+                                        "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "templates": {
+          "type": "object",
+          "description": "allows define templates which will use for render Kubernetes resources like StatefulSet, ConfigMap, Service, PVC, by default, clickhouse-operator have own templates, but you can override it",
+          "properties": {
+            "hostTemplates": {
+              "type": "array",
+              "description": "hostTemplate will use during apply to generate `clickhose-server` config files",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "template name, could use to link inside top-level `chi.spec.defaults.templates.hostTemplate`, cluster-level `chi.spec.configuration.clusters.templates.hostTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.hostTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.hostTemplate`",
+                    "type": "string"
+                  },
+                  "portDistribution": {
+                    "type": "array",
+                    "description": "define how will distribute numeric values of named ports in `Pod.spec.containers.ports` and clickhouse-server configs",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "description": "type of distribution, when `Unspecified` (default value) then all listen ports on clickhouse-server configuration in all Pods will have the same value, when `ClusterScopeIndex` then ports will increment to offset from base value depends on shard and replica index inside cluster with combination of `chi.spec.templates.podTemlates.spec.HostNetwork` it allows setup ClickHouse cluster inside Kubernetes and provide access via external network bypass Kubernetes internal network",
+                          "enum": [
+                            "",
+                            "Unspecified",
+                            "ClusterScopeIndex"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "spec": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "by default, hostname will generate, but this allows define custom name for each `clickhouse-server`",
+                        "minLength": 1,
+                        "maxLength": 15,
+                        "pattern": "^[a-zA-Z0-9-]{0,15}$"
+                      },
+                      "zkPort": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 65535
+                      },
+                      "raftPort": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 65535
+                      },
+                      "settings": {
+                        "type": "object",
+                        "description": "optional, allows configure `clickhouse-server` settings inside <yandex>...</yandex> tag in each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/conf.d/`\nMore details: https://clickhouse.tech/docs/en/operations/settings/settings/\n",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "files": {
+                        "type": "object",
+                        "description": "optional, allows define content of any setting file inside each `Pod` where this template will apply during generate `ConfigMap` which will mount in `/etc/clickhouse-server/config.d/` or `/etc/clickhouse-server/conf.d/` or `/etc/clickhouse-server/users.d/`\n",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      },
+                      "templates": {
+                        "type": "object",
+                        "description": "be careful, this part of CRD allows override template inside template, don't use it if you don't understand what you do",
+                        "properties": {
+                          "hostTemplate": {
+                            "type": "string",
+                            "description": "optional, template name from chi.spec.templates.hostTemplates, which will apply to configure every `clickhouse-server` instance during render ConfigMap resources which will mount into `Pod`"
+                          },
+                          "podTemplate": {
+                            "type": "string",
+                            "description": "optional, template name from chi.spec.templates.podTemplates, allows customization each `Pod` resource during render and reconcile each StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                          },
+                          "dataVolumeClaimTemplate": {
+                            "type": "string",
+                            "description": "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                          },
+                          "logVolumeClaimTemplate": {
+                            "type": "string",
+                            "description": "optional, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse log directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                          },
+                          "serviceTemplate": {
+                            "type": "string",
+                            "description": "optional, template name from chi.spec.templates.serviceTemplates. used for customization of the `Service` resource, created by `clickhouse-operator` to cover all clusters in whole `chi` resource"
+                          },
+                          "serviceTemplates": {
+                            "type": "array",
+                            "description": "optional, template names from chi.spec.templates.serviceTemplates. used for customization of the `Service` resources, created by `clickhouse-operator` to cover all clusters in whole `chi` resource",
+                            "nullable": true,
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "clusterServiceTemplate": {
+                            "type": "string",
+                            "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                          },
+                          "shardServiceTemplate": {
+                            "type": "string",
+                            "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each shard inside clickhouse cluster described in `chi.spec.configuration.clusters`"
+                          },
+                          "replicaServiceTemplate": {
+                            "type": "string",
+                            "description": "optional, template name from chi.spec.templates.serviceTemplates, allows customization for each `Service` resource which will created by `clickhouse-operator` which cover each replica inside each shard inside each clickhouse cluster described in `chi.spec.configuration.clusters`"
+                          },
+                          "volumeClaimTemplate": {
+                            "type": "string",
+                            "description": "optional, alias for dataVolumeClaimTemplate, template name from chi.spec.templates.volumeClaimTemplates, allows customization each `PVC` which will mount for clickhouse data directory in each `Pod` during render and reconcile every StatefulSet.spec resource described in `chi.spec.configuration.clusters`"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "podTemplates": {
+              "type": "array",
+              "description": "podTemplate will use during render `Pod` inside `StatefulSet.spec` and allows define rendered `Pod.spec`, pod scheduling distribution and pod zone\nMore information: https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatespodtemplates\n",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "template name, could use to link inside top-level `chi.spec.defaults.templates.podTemplate`, cluster-level `chi.spec.configuration.clusters.templates.podTemplate`, shard-level `chi.spec.configuration.clusters.layout.shards.temlates.podTemplate`, replica-level `chi.spec.configuration.clusters.layout.replicas.templates.podTemplate`"
+                  },
+                  "generateName": {
+                    "type": "string",
+                    "description": "allows define format for generated `Pod` name, look to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates for details about available template variables"
+                  },
+                  "zone": {
+                    "type": "object",
+                    "description": "allows define custom zone name and will separate ClickHouse `Pods` between nodes, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`",
+                    "properties": {
+                      "key": {
+                        "type": "string",
+                        "description": "optional, if defined, allows select kubernetes nodes by label with `name` equal `key`"
+                      },
+                      "values": {
+                        "type": "array",
+                        "description": "optional, if defined, allows select kubernetes nodes by label with `value` in `values`",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "distribution": {
+                    "type": "string",
+                    "description": "DEPRECATED, shortcut for `chi.spec.templates.podTemplates.spec.affinity.podAntiAffinity`",
+                    "enum": [
+                      "",
+                      "Unspecified",
+                      "OnePerHost"
+                    ]
+                  },
+                  "podDistribution": {
+                    "type": "array",
+                    "description": "define ClickHouse Pod distribution policy between Kubernetes Nodes inside Shard, Replica, Namespace, CHI, another ClickHouse cluster",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "description": "you can define multiple affinity policy types",
+                          "enum": [
+                            "",
+                            "Unspecified",
+                            "ClickHouseAntiAffinity",
+                            "ShardAntiAffinity",
+                            "ReplicaAntiAffinity",
+                            "AnotherNamespaceAntiAffinity",
+                            "AnotherClickHouseInstallationAntiAffinity",
+                            "AnotherClusterAntiAffinity",
+                            "MaxNumberPerNode",
+                            "NamespaceAffinity",
+                            "ClickHouseInstallationAffinity",
+                            "ClusterAffinity",
+                            "ShardAffinity",
+                            "ReplicaAffinity",
+                            "PreviousTailAffinity",
+                            "CircularReplication"
+                          ]
+                        },
+                        "scope": {
+                          "type": "string",
+                          "description": "scope for apply each podDistribution",
+                          "enum": [
+                            "",
+                            "Unspecified",
+                            "Shard",
+                            "Replica",
+                            "Cluster",
+                            "ClickHouseInstallation",
+                            "Namespace"
+                          ]
+                        },
+                        "number": {
+                          "type": "integer",
+                          "description": "define, how much ClickHouse Pods could be inside selected scope with selected distribution type",
+                          "minimum": 0,
+                          "maximum": 65535
+                        },
+                        "topologyKey": {
+                          "type": "string",
+                          "description": "use for inter-pod affinity look to `pod.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution.podAffinityTerm.topologyKey`,\nmore info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity\"\n"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "description": "allows pass standard object's metadata from template to Pod\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\n",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "spec": {
+                    "type": "object",
+                    "description": "allows define whole Pod.spec inside StaefulSet.spec, look to https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates for details",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "volumeClaimTemplates": {
+              "type": "array",
+              "description": "allows define template for rendering `PVC` kubernetes resource, which would use inside `Pod` for mount clickhouse `data`, clickhouse `logs` or something else\n",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "template name, could use to link inside\ntop-level `chi.spec.defaults.templates.dataVolumeClaimTemplate` or `chi.spec.defaults.templates.logVolumeClaimTemplate`,\ncluster-level `chi.spec.configuration.clusters.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.templates.logVolumeClaimTemplate`,\nshard-level `chi.spec.configuration.clusters.layout.shards.temlates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.shards.temlates.logVolumeClaimTemplate`\nreplica-level `chi.spec.configuration.clusters.layout.replicas.templates.dataVolumeClaimTemplate` or `chi.spec.configuration.clusters.layout.replicas.templates.logVolumeClaimTemplate`\n"
+                  },
+                  "provisioner": {
+                    "type": "string",
+                    "description": "defines `PVC` provisioner - be it StatefulSet or the Operator",
+                    "enum": [
+                      "",
+                      "StatefulSet",
+                      "Operator"
+                    ]
+                  },
+                  "reclaimPolicy": {
+                    "type": "string",
+                    "description": "defines behavior of `PVC` deletion.\n`Delete` by default, if `Retain` specified then `PVC` will be kept when deleting StatefulSet\n",
+                    "enum": [
+                      "",
+                      "Retain",
+                      "Delete"
+                    ]
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "description": "allows to pass standard object's metadata from template to PVC\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\n",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "spec": {
+                    "type": "object",
+                    "description": "allows define all aspects of `PVC` resource\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims\n",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "serviceTemplates": {
+              "type": "array",
+              "description": "allows define template for rendering `Service` which would get endpoint from Pods which scoped chi-wide, cluster-wide, shard-wide, replica-wide level\n",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "template name, could use to link inside\nchi-level `chi.spec.defaults.templates.serviceTemplate`\ncluster-level `chi.spec.configuration.clusters.templates.clusterServiceTemplate`\nshard-level `chi.spec.configuration.clusters.layout.shards.temlates.shardServiceTemplate`\nreplica-level `chi.spec.configuration.clusters.layout.replicas.templates.replicaServiceTemplate` or `chi.spec.configuration.clusters.layout.shards.replicas.replicaServiceTemplate`\n"
+                  },
+                  "generateName": {
+                    "type": "string",
+                    "description": "allows define format for generated `Service` name,\nlook to https://github.com/Altinity/clickhouse-operator/blob/master/docs/custom_resource_explained.md#spectemplatesservicetemplates\nfor details about available template variables\"\n"
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "description": "allows pass standard object's metadata from template to Service\nCould be use for define specificly for Cloud Provider metadata which impact to behavior of service\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata\n",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  },
+                  "spec": {
+                    "type": "object",
+                    "description": "describe behavior of generated Service\nMore info: https://kubernetes.io/docs/concepts/services-networking/service/\n",
+                    "x-kubernetes-preserve-unknown-fields": true
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/master-standalone/clickhouseoperatorconfiguration-clickhouse-v1.json
+++ b/master-standalone/clickhouseoperatorconfiguration-clickhouse-v1.json
@@ -17,11 +17,9 @@
           "description": "Parameters for watch kubernetes resources which used by clickhouse-operator deployment",
           "properties": {
             "namespaces": {
-              "type": "array",
+              "type": "object",
               "description": "List of namespaces where clickhouse-operator watches for events.",
-              "items": {
-                "type": "string"
-              }
+              "x-kubernetes-preserve-unknown-fields": true
             }
           },
           "additionalProperties": false
@@ -38,18 +36,19 @@
                   "properties": {
                     "path": {
                       "type": "object",
+                      "description": "Each 'path' can be either absolute or relative.\nIn case path is absolute - it is used as is.\nIn case path is relative - it is relative to the folder where configuration file you are reading right now is located.\n",
                       "properties": {
                         "common": {
                           "type": "string",
-                          "description": "Path to the folder where ClickHouse configuration files common for all instances within a CHI are located. Default - config.d"
+                          "description": "Path to the folder where ClickHouse configuration files common for all instances within a CHI are located.\nDefault value - config.d\n"
                         },
                         "host": {
                           "type": "string",
-                          "description": "Path to the folder where ClickHouse configuration files unique for each instance (host) within a CHI are located. Default - conf.d"
+                          "description": "Path to the folder where ClickHouse configuration files unique for each instance (host) within a CHI are located.\nDefault value - conf.d\n"
                         },
                         "user": {
                           "type": "string",
-                          "description": "Path to the folder where ClickHouse configuration files with users settings are located. Files are common for all instances within a CHI. Default - users.d"
+                          "description": "Path to the folder where ClickHouse configuration files with users settings are located.\nFiles are common for all instances within a CHI.\nDefault value - users.d\n"
                         }
                       },
                       "additionalProperties": false
@@ -122,7 +121,8 @@
                         "description": "Set of configuration rules for specified ClickHouse version",
                         "items": {
                           "type": "object",
-                          "description": "setting: value pairs for configuration restart policy"
+                          "description": "setting: value pairs for configuration restart policy",
+                          "x-kubernetes-preserve-unknown-fields": true
                         }
                       }
                     },
@@ -194,6 +194,66 @@
               },
               "additionalProperties": false
             },
+            "addons": {
+              "type": "object",
+              "description": "Configuration addons specifies additional settings",
+              "properties": {
+                "rules": {
+                  "type": "array",
+                  "description": "Array of set of rules per specified ClickHouse versions",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "version": {
+                        "type": "string",
+                        "description": "ClickHouse version expression"
+                      },
+                      "spec": {
+                        "type": "object",
+                        "description": "spec",
+                        "properties": {
+                          "configuration": {
+                            "type": "object",
+                            "description": "allows configure multiple aspects and behavior for `clickhouse-server` instance and also allows describe multiple `clickhouse-server` clusters inside one `chi` resource",
+                            "properties": {
+                              "users": {
+                                "type": "object",
+                                "description": "see same section from CR spec",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              },
+                              "profiles": {
+                                "type": "object",
+                                "description": "see same section from CR spec",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              },
+                              "quotas": {
+                                "type": "object",
+                                "description": "see same section from CR spec",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              },
+                              "settings": {
+                                "type": "object",
+                                "description": "see same section from CR spec",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              },
+                              "files": {
+                                "type": "object",
+                                "description": "see same section from CR spec",
+                                "x-kubernetes-preserve-unknown-fields": true
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
             "metrics": {
               "type": "object",
               "description": "parameters which use for connect to fetch metrics from clickhouse by clickhouse-operator",
@@ -210,6 +270,10 @@
                     }
                   },
                   "additionalProperties": false
+                },
+                "tablesRegexp": {
+                  "type": "string",
+                  "description": "Regexp to match tables in system database to fetch metrics from.\nMultiple tables can be matched using regexp. Matched tables are merged using merge() table function.\nDefault is \"^(metrics|custom_metrics)$\".\n"
                 }
               },
               "additionalProperties": false
@@ -228,6 +292,7 @@
                   "type": "string",
                   "description": "CHI template updates handling policy\nPossible policy values:\n  - ReadOnStart. Accept CHIT updates on the operators start only.\n  - ApplyOnNextReconcile. Accept CHIT updates at all time. Apply news CHITs on next regular reconcile of the CHI\n",
                   "enum": [
+                    "",
                     "ReadOnStart",
                     "ApplyOnNextReconcile"
                   ]
@@ -301,6 +366,21 @@
                     "onFailure": {
                       "type": "string",
                       "description": "What to do in case updated StatefulSet is not in Ready after `statefulSetUpdateTimeout` seconds\nPossible options:\n1. abort - do nothing, just break the process and wait for admin.\n2. rollback (default) - delete Pod and rollback StatefulSet to previous Generation. Pod would be recreated by StatefulSet based on rollback-ed configuration.\n3. ignore - ignore error, pretend nothing happened and move on to the next StatefulSet.\n"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "recreate": {
+                  "type": "object",
+                  "description": "Behavior during recreate StatefulSet",
+                  "properties": {
+                    "onDataLoss": {
+                      "type": "string",
+                      "description": "What to do in case operator needs to recreate StatefulSet due to PVC data loss or missing volumes.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet.\n2. recreate (default) - proceed and recreate StatefulSet.\n"
+                    },
+                    "onUpdateFailure": {
+                      "type": "string",
+                      "description": "What to do in case operator needs to recreate StatefulSet due to update failure or StatefulSet not ready.\nPossible options:\n1. abort - abort the process, do nothing with the problematic StatefulSet.\n2. recreate (default) - proceed and recreate StatefulSet.\n"
                     }
                   },
                   "additionalProperties": false
@@ -401,6 +481,240 @@
                         "Enabled",
                         "enabled"
                       ]
+                    },
+                    "replicas": {
+                      "type": "object",
+                      "description": "Whether the operator during reconcile procedure should wait for replicas to catch-up",
+                      "properties": {
+                        "all": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should wait for all replicas to catch-up",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "new": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should wait for new replicas to catch-up",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "delay": {
+                          "type": "integer",
+                          "description": "replication max absolute delay to consider replica is not delayed"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "probes": {
+                      "type": "object",
+                      "description": "What probes the operator should wait during host launch procedure",
+                      "properties": {
+                        "startup": {
+                          "type": "string",
+                          "description": "Whether the operator during host launch procedure should wait for startup probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to do not wait.\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "readiness": {
+                          "type": "string",
+                          "description": "Whether the operator during host launch procedure should wait for readiness probe to succeed.\nIn case probe is unspecified wait is assumed to be completed successfully.\nDefault option value is to wait.\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                "drop": {
+                  "type": "object",
+                  "properties": {
+                    "replicas": {
+                      "type": "object",
+                      "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted or recreated\n",
+                      "properties": {
+                        "onDelete": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop replicas when replica is deleted\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "onLostVolume": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop replicas when replica volume is lost\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        },
+                        "active": {
+                          "type": "string",
+                          "description": "Whether the operator during reconcile procedure should drop active replicas when replica is deleted or recreated\n",
+                          "enum": [
+                            "",
+                            "0",
+                            "1",
+                            "False",
+                            "false",
+                            "True",
+                            "true",
+                            "No",
+                            "no",
+                            "Yes",
+                            "yes",
+                            "Off",
+                            "off",
+                            "On",
+                            "on",
+                            "Disable",
+                            "disable",
+                            "Enable",
+                            "enable",
+                            "Disabled",
+                            "disabled",
+                            "Enabled",
+                            "enabled"
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
                     }
                   },
                   "additionalProperties": false
@@ -482,6 +796,157 @@
           },
           "additionalProperties": false
         },
+        "metrics": {
+          "type": "object",
+          "description": "defines metrics exporter options",
+          "properties": {
+            "labels": {
+              "type": "object",
+              "description": "defines metric labels options",
+              "properties": {
+                "exclude": {
+                  "type": "array",
+                  "description": "When adding labels to a metric exclude labels with names from the following list\n",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "status": {
+          "type": "object",
+          "description": "defines status options",
+          "properties": {
+            "fields": {
+              "type": "object",
+              "description": "defines status fields options",
+              "properties": {
+                "action": {
+                  "type": "string",
+                  "description": "Whether the operator should fill status field 'action'",
+                  "enum": [
+                    "",
+                    "0",
+                    "1",
+                    "False",
+                    "false",
+                    "True",
+                    "true",
+                    "No",
+                    "no",
+                    "Yes",
+                    "yes",
+                    "Off",
+                    "off",
+                    "On",
+                    "on",
+                    "Disable",
+                    "disable",
+                    "Enable",
+                    "enable",
+                    "Disabled",
+                    "disabled",
+                    "Enabled",
+                    "enabled"
+                  ]
+                },
+                "actions": {
+                  "type": "string",
+                  "description": "Whether the operator should fill status field 'actions'",
+                  "enum": [
+                    "",
+                    "0",
+                    "1",
+                    "False",
+                    "false",
+                    "True",
+                    "true",
+                    "No",
+                    "no",
+                    "Yes",
+                    "yes",
+                    "Off",
+                    "off",
+                    "On",
+                    "on",
+                    "Disable",
+                    "disable",
+                    "Enable",
+                    "enable",
+                    "Disabled",
+                    "disabled",
+                    "Enabled",
+                    "enabled"
+                  ]
+                },
+                "error": {
+                  "type": "string",
+                  "description": "Whether the operator should fill status field 'error'",
+                  "enum": [
+                    "",
+                    "0",
+                    "1",
+                    "False",
+                    "false",
+                    "True",
+                    "true",
+                    "No",
+                    "no",
+                    "Yes",
+                    "yes",
+                    "Off",
+                    "off",
+                    "On",
+                    "on",
+                    "Disable",
+                    "disable",
+                    "Enable",
+                    "enable",
+                    "Disabled",
+                    "disabled",
+                    "Enabled",
+                    "enabled"
+                  ]
+                },
+                "errors": {
+                  "type": "string",
+                  "description": "Whether the operator should fill status field 'errors'",
+                  "enum": [
+                    "",
+                    "0",
+                    "1",
+                    "False",
+                    "false",
+                    "True",
+                    "true",
+                    "No",
+                    "no",
+                    "Yes",
+                    "yes",
+                    "Off",
+                    "off",
+                    "On",
+                    "on",
+                    "Disable",
+                    "disable",
+                    "Enable",
+                    "enable",
+                    "Disabled",
+                    "disabled",
+                    "Enabled",
+                    "enabled"
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
         "statefulSet": {
           "type": "object",
           "description": "define StatefulSet-specific parameters",
@@ -534,8 +999,7 @@
           },
           "additionalProperties": false
         }
-      },
-      "additionalProperties": false
+      }
     }
   }
 }


### PR DESCRIPTION
Update ClickHouse CRDs so that we can validate the custom resources without schema errors.

### Dependencies

To avoid breaking the CI on multiple repos, we are going to reference this branch `SRE-12580-update-clickhouse-crds` in the following repos:
- [x] https://github.com/xgen-cloud/kube-resources/pull/10495
- [x] https://github.com/xgen-cloud/helm-charts/pull/1135

Note: we'll delete the `SRE-12580-update-clickhouse-crds` branch once we have done the  cut-over to `master` in the repos mentioned above.