### PR TITLE
SRE-13552 Add VPA CRDs

### DIFF
--- a/master-standalone-strict/verticalpodautoscaler-autoscaling-v1.json
+++ b/master-standalone-strict/verticalpodautoscaler-autoscaling-v1.json
@@ -1,0 +1,484 @@
+{
+  "description": "VerticalPodAutoscaler is the configuration for a vertical pod\nautoscaler, which automatically manages pod resources based on historical and\nreal time resource utilization.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of the behavior of the autoscaler.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.",
+      "properties": {
+        "recommenders": {
+          "description": "Recommender responsible for generating recommendation for this object.\nList should be empty (then the default recommender will generate the\nrecommendation) or contain exactly one recommender.",
+          "items": {
+            "description": "VerticalPodAutoscalerRecommenderSelector points to a specific Vertical Pod Autoscaler recommender.\nIn the future it might pass parameters to the recommender.",
+            "properties": {
+              "name": {
+                "description": "Name of the recommender responsible for generating recommendation for this object.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "resourcePolicy": {
+          "description": "Controls how the autoscaler computes recommended resources.\nThe resource policy may be used to set constraints on the recommendations\nfor individual containers.\nIf any individual containers need to be excluded from getting the VPA recommendations, then\nit must be disabled explicitly by setting mode to \"Off\" under containerPolicies.\nIf not specified, the autoscaler computes recommended resources for all containers in the pod,\nwithout additional constraints.",
+          "properties": {
+            "containerPolicies": {
+              "description": "Per-container resource policies.",
+              "items": {
+                "description": "ContainerResourcePolicy controls how autoscaler computes the recommended\nresources for a specific container.",
+                "properties": {
+                  "containerName": {
+                    "description": "Name of the container or DefaultContainerResourcePolicy, in which\ncase the policy is used by the containers that don't have their own\npolicy specified.",
+                    "type": "string"
+                  },
+                  "controlledResources": {
+                    "description": "Specifies the type of recommendations that will be computed\n(and possibly applied) by VPA.\nIf not specified, the default of [ResourceCPU, ResourceMemory] will be used.",
+                    "items": {
+                      "description": "ResourceName is the name identifying various resources in a ResourceList.",
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "controlledValues": {
+                    "description": "Specifies which resource values should be controlled.\nThe default is \"RequestsAndLimits\".",
+                    "enum": [
+                      "RequestsAndLimits",
+                      "RequestsOnly"
+                    ],
+                    "type": "string"
+                  },
+                  "maxAllowed": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "description": "Specifies the maximum amount of resources that will be recommended\nfor the container. The default is no maximum.",
+                    "type": "object"
+                  },
+                  "minAllowed": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "description": "Specifies the minimal amount of resources that will be recommended\nfor the container. The default is no minimum.",
+                    "type": "object"
+                  },
+                  "mode": {
+                    "description": "Whether autoscaler is enabled for the container. The default is \"Auto\".",
+                    "enum": [
+                      "Auto",
+                      "Off"
+                    ],
+                    "type": "string"
+                  },
+                  "oomBumpUpRatio": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "oomBumpUpRatio is the ratio to increase memory when OOM is detected.",
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "oomMinBumpUp": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "oomMinBumpUp is the minimum increase in memory when OOM is detected.",
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "startupBoost": {
+                    "description": "startupBoost specifies the startup boost policy for the container.\nThis overrides any pod-level startup boost policy.\nThe startup boost policy takes precedence over the rest of the fields in\nthis struct, except for ContainerName and ControlledValues.",
+                    "properties": {
+                      "cpu": {
+                        "description": "cpu specifies the CPU startup boost policy.\nIf this field is not set, no startup boost is applied.",
+                        "properties": {
+                          "durationSeconds": {
+                            "description": "durationSeconds indicates for how long to keep the pod boosted after it goes to Ready.\nDefaults to 0.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "factor": {
+                            "description": "factor specifies the factor to apply to the resource request.\nThis field is required when Type is \"Factor\".",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "quantity": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "quantity specifies the absolute resource quantity to be used as the\nresource request and limit during the boost phase.\nThis field is required when Type is \"Quantity\".",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": {
+                            "description": "type specifies the kind of boost to apply.\nSupported values are: \"Factor\", \"Quantity\".\nNo startupboost will be applied for unrecognized values.",
+                            "enum": [
+                              "Factor",
+                              "Quantity"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "factor is required when type is Factor and forbidden otherwise",
+                            "rule": "(self.type == 'Factor') == has(self.factor)"
+                          },
+                          {
+                            "message": "quantity is required when type is Quantity and forbidden otherwise",
+                            "rule": "(self.type == 'Quantity') == has(self.quantity)"
+                          }
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "startupBoost": {
+          "description": "startupBoost specifies the startup boost policy for the pod.",
+          "properties": {
+            "cpu": {
+              "description": "cpu specifies the CPU startup boost policy.\nIf this field is not set, no startup boost is applied.",
+              "properties": {
+                "durationSeconds": {
+                  "description": "durationSeconds indicates for how long to keep the pod boosted after it goes to Ready.\nDefaults to 0.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "factor": {
+                  "description": "factor specifies the factor to apply to the resource request.\nThis field is required when Type is \"Factor\".",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "quantity": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "quantity specifies the absolute resource quantity to be used as the\nresource request and limit during the boost phase.\nThis field is required when Type is \"Quantity\".",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true
+                },
+                "type": {
+                  "description": "type specifies the kind of boost to apply.\nSupported values are: \"Factor\", \"Quantity\".\nNo startupboost will be applied for unrecognized values.",
+                  "enum": [
+                    "Factor",
+                    "Quantity"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "factor is required when type is Factor and forbidden otherwise",
+                  "rule": "(self.type == 'Factor') == has(self.factor)"
+                },
+                {
+                  "message": "quantity is required when type is Quantity and forbidden otherwise",
+                  "rule": "(self.type == 'Quantity') == has(self.quantity)"
+                }
+              ],
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "targetRef": {
+          "description": "TargetRef points to the controller managing the set of pods for the\nautoscaler to control - e.g. Deployment, StatefulSet. VerticalPodAutoscaler\ncan be targeted at controller implementing scale subresource (the pod set is\nretrieved from the controller's ScaleStatus) or some well known controllers\n(e.g. for DaemonSet the pod set is read from the controller's spec).\nIf VerticalPodAutoscaler cannot use specified target it will report\nConfigUnsupported condition.\nNote that VerticalPodAutoscaler does not require full implementation\nof scale subresource - it will not use it to modify the replica count.\nThe only thing retrieved is a label selector matching pods grouped by\nthe target resource.",
+          "properties": {
+            "apiVersion": {
+              "description": "apiVersion is the API version of the referent",
+              "type": "string"
+            },
+            "kind": {
+              "description": "kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "updatePolicy": {
+          "description": "Describes the rules on how changes are applied to the pods.\nIf not specified, all fields in the `PodUpdatePolicy` are set to their\ndefault values.",
+          "properties": {
+            "evictAfterOOMSeconds": {
+              "description": "evictAfterOOMSeconds specifies the time in seconds to wait after an OOM event before\nconsidering the pod for eviction. Pods that have OOMed in less than this time\nsince start will be evicted.",
+              "format": "int32",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "evictionRequirements": {
+              "description": "EvictionRequirements is a list of EvictionRequirements that need to\nevaluate to true in order for a Pod to be evicted. If more than one\nEvictionRequirement is specified, all of them need to be fulfilled to allow eviction.",
+              "items": {
+                "description": "EvictionRequirement defines a single condition which needs to be true in\norder to evict a Pod",
+                "properties": {
+                  "changeRequirement": {
+                    "description": "EvictionChangeRequirement refers to the relationship between the new target recommendation for a Pod and its current requests, what kind of change is necessary for the Pod to be evicted",
+                    "enum": [
+                      "TargetHigherThanRequests",
+                      "TargetLowerThanRequests"
+                    ],
+                    "type": "string"
+                  },
+                  "resources": {
+                    "description": "Resources is a list of one or more resources that the condition applies\nto. If more than one resource is given, the EvictionRequirement is fulfilled\nif at least one resource meets `changeRequirement`.",
+                    "items": {
+                      "description": "ResourceName is the name identifying various resources in a ResourceList.",
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "changeRequirement",
+                  "resources"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "minReplicas": {
+              "description": "Minimal number of replicas which need to be alive for Updater to attempt\npod eviction (pending other checks like PDB). Only positive values are\nallowed. Overrides global '--min-replicas' flag.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "updateMode": {
+              "description": "Controls when autoscaler applies changes to the pod resources.\nThe default is 'Recreate'.",
+              "enum": [
+                "Off",
+                "Initial",
+                "Recreate",
+                "InPlaceOrRecreate",
+                "Auto"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "targetRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Current information about the autoscaler.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions is the set of conditions required for this autoscaler to scale its target,\nand indicates whether or not those conditions are met.",
+          "items": {
+            "description": "VerticalPodAutoscalerCondition describes the state of\na VerticalPodAutoscaler at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from\none status to another",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human-readable explanation containing details about\nthe transition",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason is the reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "status is the status of the condition (True, False, Unknown)",
+                "type": "string"
+              },
+              "type": {
+                "description": "type describes the current condition",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "recommendation": {
+          "description": "The most recently computed amount of resources recommended by the\nautoscaler for the controlled pods.",
+          "properties": {
+            "containerRecommendations": {
+              "description": "Resources recommended by the autoscaler for each container.",
+              "items": {
+                "description": "RecommendedContainerResources is the recommendation of resources computed by\nautoscaler for a specific container. Respects the container resource policy\nif present in the spec. In particular the recommendation is not produced for\ncontainers with `ContainerScalingMode` set to 'Off'.",
+                "properties": {
+                  "containerName": {
+                    "description": "Name of the container.",
+                    "type": "string"
+                  },
+                  "lowerBound": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "description": "Minimum recommended amount of resources. Observes ContainerResourcePolicy.\nThis amount is not guaranteed to be sufficient for the application to operate in a stable way, however\nrunning with less resources is likely to have significant impact on performance/availability.",
+                    "type": "object"
+                  },
+                  "target": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "description": "Recommended amount of resources. Observes ContainerResourcePolicy.",
+                    "type": "object"
+                  },
+                  "uncappedTarget": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "description": "The most recent recommended resources target computed by the autoscaler\nfor the controlled pods, based only on actual resource usage, not taking\ninto account the ContainerResourcePolicy.\nMay differ from the Recommendation if the actual resource usage causes\nthe target to violate the ContainerResourcePolicy (lower than MinAllowed\nor higher that MaxAllowed).\nUsed only as status indication, will not affect actual resource assignment.",
+                    "type": "object"
+                  },
+                  "upperBound": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "description": "Maximum recommended amount of resources. Observes ContainerResourcePolicy.\nAny resources allocated beyond this value are likely wasted. This value may be larger than the maximum\namount of application is actually capable of consuming.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "target"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}

--- a/master-standalone/verticalpodautoscaler-autoscaling-v1.json
+++ b/master-standalone/verticalpodautoscaler-autoscaling-v1.json
@@ -1,0 +1,484 @@
+{
+  "description": "VerticalPodAutoscaler is the configuration for a vertical pod\nautoscaler, which automatically manages pod resources based on historical and\nreal time resource utilization.",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "Specification of the behavior of the autoscaler.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.",
+      "properties": {
+        "recommenders": {
+          "description": "Recommender responsible for generating recommendation for this object.\nList should be empty (then the default recommender will generate the\nrecommendation) or contain exactly one recommender.",
+          "items": {
+            "description": "VerticalPodAutoscalerRecommenderSelector points to a specific Vertical Pod Autoscaler recommender.\nIn the future it might pass parameters to the recommender.",
+            "properties": {
+              "name": {
+                "description": "Name of the recommender responsible for generating recommendation for this object.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "resourcePolicy": {
+          "description": "Controls how the autoscaler computes recommended resources.\nThe resource policy may be used to set constraints on the recommendations\nfor individual containers.\nIf any individual containers need to be excluded from getting the VPA recommendations, then\nit must be disabled explicitly by setting mode to \"Off\" under containerPolicies.\nIf not specified, the autoscaler computes recommended resources for all containers in the pod,\nwithout additional constraints.",
+          "properties": {
+            "containerPolicies": {
+              "description": "Per-container resource policies.",
+              "items": {
+                "description": "ContainerResourcePolicy controls how autoscaler computes the recommended\nresources for a specific container.",
+                "properties": {
+                  "containerName": {
+                    "description": "Name of the container or DefaultContainerResourcePolicy, in which\ncase the policy is used by the containers that don't have their own\npolicy specified.",
+                    "type": "string"
+                  },
+                  "controlledResources": {
+                    "description": "Specifies the type of recommendations that will be computed\n(and possibly applied) by VPA.\nIf not specified, the default of [ResourceCPU, ResourceMemory] will be used.",
+                    "items": {
+                      "description": "ResourceName is the name identifying various resources in a ResourceList.",
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "controlledValues": {
+                    "description": "Specifies which resource values should be controlled.\nThe default is \"RequestsAndLimits\".",
+                    "enum": [
+                      "RequestsAndLimits",
+                      "RequestsOnly"
+                    ],
+                    "type": "string"
+                  },
+                  "maxAllowed": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "description": "Specifies the maximum amount of resources that will be recommended\nfor the container. The default is no maximum.",
+                    "type": "object"
+                  },
+                  "minAllowed": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "description": "Specifies the minimal amount of resources that will be recommended\nfor the container. The default is no minimum.",
+                    "type": "object"
+                  },
+                  "mode": {
+                    "description": "Whether autoscaler is enabled for the container. The default is \"Auto\".",
+                    "enum": [
+                      "Auto",
+                      "Off"
+                    ],
+                    "type": "string"
+                  },
+                  "oomBumpUpRatio": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "oomBumpUpRatio is the ratio to increase memory when OOM is detected.",
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "oomMinBumpUp": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "description": "oomMinBumpUp is the minimum increase in memory when OOM is detected.",
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "startupBoost": {
+                    "description": "startupBoost specifies the startup boost policy for the container.\nThis overrides any pod-level startup boost policy.\nThe startup boost policy takes precedence over the rest of the fields in\nthis struct, except for ContainerName and ControlledValues.",
+                    "properties": {
+                      "cpu": {
+                        "description": "cpu specifies the CPU startup boost policy.\nIf this field is not set, no startup boost is applied.",
+                        "properties": {
+                          "durationSeconds": {
+                            "description": "durationSeconds indicates for how long to keep the pod boosted after it goes to Ready.\nDefaults to 0.",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "factor": {
+                            "description": "factor specifies the factor to apply to the resource request.\nThis field is required when Type is \"Factor\".",
+                            "format": "int32",
+                            "type": "integer"
+                          },
+                          "quantity": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "description": "quantity specifies the absolute resource quantity to be used as the\nresource request and limit during the boost phase.\nThis field is required when Type is \"Quantity\".",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": {
+                            "description": "type specifies the kind of boost to apply.\nSupported values are: \"Factor\", \"Quantity\".\nNo startupboost will be applied for unrecognized values.",
+                            "enum": [
+                              "Factor",
+                              "Quantity"
+                            ],
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "factor is required when type is Factor and forbidden otherwise",
+                            "rule": "(self.type == 'Factor') == has(self.factor)"
+                          },
+                          {
+                            "message": "quantity is required when type is Quantity and forbidden otherwise",
+                            "rule": "(self.type == 'Quantity') == has(self.quantity)"
+                          }
+                        ],
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "startupBoost": {
+          "description": "startupBoost specifies the startup boost policy for the pod.",
+          "properties": {
+            "cpu": {
+              "description": "cpu specifies the CPU startup boost policy.\nIf this field is not set, no startup boost is applied.",
+              "properties": {
+                "durationSeconds": {
+                  "description": "durationSeconds indicates for how long to keep the pod boosted after it goes to Ready.\nDefaults to 0.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "factor": {
+                  "description": "factor specifies the factor to apply to the resource request.\nThis field is required when Type is \"Factor\".",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "quantity": {
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "description": "quantity specifies the absolute resource quantity to be used as the\nresource request and limit during the boost phase.\nThis field is required when Type is \"Quantity\".",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true
+                },
+                "type": {
+                  "description": "type specifies the kind of boost to apply.\nSupported values are: \"Factor\", \"Quantity\".\nNo startupboost will be applied for unrecognized values.",
+                  "enum": [
+                    "Factor",
+                    "Quantity"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ],
+              "type": "object",
+              "x-kubernetes-validations": [
+                {
+                  "message": "factor is required when type is Factor and forbidden otherwise",
+                  "rule": "(self.type == 'Factor') == has(self.factor)"
+                },
+                {
+                  "message": "quantity is required when type is Quantity and forbidden otherwise",
+                  "rule": "(self.type == 'Quantity') == has(self.quantity)"
+                }
+              ],
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "targetRef": {
+          "description": "TargetRef points to the controller managing the set of pods for the\nautoscaler to control - e.g. Deployment, StatefulSet. VerticalPodAutoscaler\ncan be targeted at controller implementing scale subresource (the pod set is\nretrieved from the controller's ScaleStatus) or some well known controllers\n(e.g. for DaemonSet the pod set is read from the controller's spec).\nIf VerticalPodAutoscaler cannot use specified target it will report\nConfigUnsupported condition.\nNote that VerticalPodAutoscaler does not require full implementation\nof scale subresource - it will not use it to modify the replica count.\nThe only thing retrieved is a label selector matching pods grouped by\nthe target resource.",
+          "properties": {
+            "apiVersion": {
+              "description": "apiVersion is the API version of the referent",
+              "type": "string"
+            },
+            "kind": {
+              "description": "kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "name is the name of the referent; More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object",
+          "x-kubernetes-map-type": "atomic",
+          "additionalProperties": false
+        },
+        "updatePolicy": {
+          "description": "Describes the rules on how changes are applied to the pods.\nIf not specified, all fields in the `PodUpdatePolicy` are set to their\ndefault values.",
+          "properties": {
+            "evictAfterOOMSeconds": {
+              "description": "evictAfterOOMSeconds specifies the time in seconds to wait after an OOM event before\nconsidering the pod for eviction. Pods that have OOMed in less than this time\nsince start will be evicted.",
+              "format": "int32",
+              "minimum": 1,
+              "type": "integer"
+            },
+            "evictionRequirements": {
+              "description": "EvictionRequirements is a list of EvictionRequirements that need to\nevaluate to true in order for a Pod to be evicted. If more than one\nEvictionRequirement is specified, all of them need to be fulfilled to allow eviction.",
+              "items": {
+                "description": "EvictionRequirement defines a single condition which needs to be true in\norder to evict a Pod",
+                "properties": {
+                  "changeRequirement": {
+                    "description": "EvictionChangeRequirement refers to the relationship between the new target recommendation for a Pod and its current requests, what kind of change is necessary for the Pod to be evicted",
+                    "enum": [
+                      "TargetHigherThanRequests",
+                      "TargetLowerThanRequests"
+                    ],
+                    "type": "string"
+                  },
+                  "resources": {
+                    "description": "Resources is a list of one or more resources that the condition applies\nto. If more than one resource is given, the EvictionRequirement is fulfilled\nif at least one resource meets `changeRequirement`.",
+                    "items": {
+                      "description": "ResourceName is the name identifying various resources in a ResourceList.",
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "changeRequirement",
+                  "resources"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            },
+            "minReplicas": {
+              "description": "Minimal number of replicas which need to be alive for Updater to attempt\npod eviction (pending other checks like PDB). Only positive values are\nallowed. Overrides global '--min-replicas' flag.",
+              "format": "int32",
+              "type": "integer"
+            },
+            "updateMode": {
+              "description": "Controls when autoscaler applies changes to the pod resources.\nThe default is 'Recreate'.",
+              "enum": [
+                "Off",
+                "Initial",
+                "Recreate",
+                "InPlaceOrRecreate",
+                "Auto"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "targetRef"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "Current information about the autoscaler.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions is the set of conditions required for this autoscaler to scale its target,\nand indicates whether or not those conditions are met.",
+          "items": {
+            "description": "VerticalPodAutoscalerCondition describes the state of\na VerticalPodAutoscaler at a certain point.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from\none status to another",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "message is a human-readable explanation containing details about\nthe transition",
+                "type": "string"
+              },
+              "reason": {
+                "description": "reason is the reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "status is the status of the condition (True, False, Unknown)",
+                "type": "string"
+              },
+              "type": {
+                "description": "type describes the current condition",
+                "type": "string"
+              }
+            },
+            "required": [
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "recommendation": {
+          "description": "The most recently computed amount of resources recommended by the\nautoscaler for the controlled pods.",
+          "properties": {
+            "containerRecommendations": {
+              "description": "Resources recommended by the autoscaler for each container.",
+              "items": {
+                "description": "RecommendedContainerResources is the recommendation of resources computed by\nautoscaler for a specific container. Respects the container resource policy\nif present in the spec. In particular the recommendation is not produced for\ncontainers with `ContainerScalingMode` set to 'Off'.",
+                "properties": {
+                  "containerName": {
+                    "description": "Name of the container.",
+                    "type": "string"
+                  },
+                  "lowerBound": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "description": "Minimum recommended amount of resources. Observes ContainerResourcePolicy.\nThis amount is not guaranteed to be sufficient for the application to operate in a stable way, however\nrunning with less resources is likely to have significant impact on performance/availability.",
+                    "type": "object"
+                  },
+                  "target": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "description": "Recommended amount of resources. Observes ContainerResourcePolicy.",
+                    "type": "object"
+                  },
+                  "uncappedTarget": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "description": "The most recent recommended resources target computed by the autoscaler\nfor the controlled pods, based only on actual resource usage, not taking\ninto account the ContainerResourcePolicy.\nMay differ from the Recommendation if the actual resource usage causes\nthe target to violate the ContainerResourcePolicy (lower than MinAllowed\nor higher that MaxAllowed).\nUsed only as status indication, will not affect actual resource assignment.",
+                    "type": "object"
+                  },
+                  "upperBound": {
+                    "additionalProperties": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ],
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "description": "Maximum recommended amount of resources. Observes ContainerResourcePolicy.\nAny resources allocated beyond this value are likely wasted. This value may be larger than the maximum\namount of application is actually capable of consuming.",
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "target"
+                ],
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "spec"
+  ],
+  "type": "object"
+}


### PR DESCRIPTION
This PR fixes the following error in the `xgen-service` helm chart CI:

> /tmp/bats-run-D8eBEq/test/13/rendered-templates.yaml - VerticalPodAutoscaler awesome-service failed validation: could not find schema for VerticalPodAutoscaler

