### PR TITLE
SRE-14683: Add Flink crds

### DIFF
--- a/master-standalone-strict/flinkbluegreendeployment_v1beta1.json
+++ b/master-standalone-strict/flinkbluegreendeployment_v1beta1.json
@@ -1,0 +1,18498 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "ingress": {
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "className": {
+              "type": "string"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "template": {
+              "type": "string"
+            },
+            "tls": {
+              "items": {
+                "properties": {
+                  "hosts": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "secretName": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "configuration": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "template": {
+          "properties": {
+            "metadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "creationTimestamp": {
+                  "type": "string"
+                },
+                "deletionGracePeriodSeconds": {
+                  "type": "integer"
+                },
+                "deletionTimestamp": {
+                  "type": "string"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "generateName": {
+                  "type": "string"
+                },
+                "generation": {
+                  "type": "integer"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "managedFields": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "fieldsType": {
+                        "type": "string"
+                      },
+                      "fieldsV1": {
+                        "type": "object"
+                      },
+                      "manager": {
+                        "type": "string"
+                      },
+                      "operation": {
+                        "type": "string"
+                      },
+                      "subresource": {
+                        "type": "string"
+                      },
+                      "time": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "uid": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "resourceVersion": {
+                  "type": "string"
+                },
+                "selfLink": {
+                  "type": "string"
+                },
+                "uid": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "properties": {
+                "flinkConfiguration": {
+                  "x-kubernetes-preserve-unknown-fields": true
+                },
+                "flinkVersion": {
+                  "enum": [
+                    "v1_13",
+                    "v1_14",
+                    "v1_15",
+                    "v1_16",
+                    "v1_17",
+                    "v1_18",
+                    "v1_19",
+                    "v1_20",
+                    "v2_0",
+                    "v2_1",
+                    "v2_2"
+                  ],
+                  "type": "string"
+                },
+                "image": {
+                  "type": "string"
+                },
+                "imagePullPolicy": {
+                  "type": "string"
+                },
+                "ingress": {
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "className": {
+                      "type": "string"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "template": {
+                      "type": "string"
+                    },
+                    "tls": {
+                      "items": {
+                        "properties": {
+                          "hosts": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "job": {
+                  "properties": {
+                    "allowNonRestoredState": {
+                      "type": "boolean"
+                    },
+                    "args": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "autoscalerResetNonce": {
+                      "type": "integer"
+                    },
+                    "checkpointTriggerNonce": {
+                      "type": "integer"
+                    },
+                    "entryClass": {
+                      "type": "string"
+                    },
+                    "initialSavepointPath": {
+                      "type": "string"
+                    },
+                    "jarURI": {
+                      "type": "string"
+                    },
+                    "parallelism": {
+                      "type": "integer"
+                    },
+                    "savepointRedeployNonce": {
+                      "type": "integer"
+                    },
+                    "savepointTriggerNonce": {
+                      "type": "integer"
+                    },
+                    "state": {
+                      "enum": [
+                        "running",
+                        "suspended"
+                      ],
+                      "type": "string"
+                    },
+                    "upgradeMode": {
+                      "enum": [
+                        "last-state",
+                        "savepoint",
+                        "stateless"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "jobManager": {
+                  "properties": {
+                    "podTemplate": {
+                      "properties": {
+                        "apiVersion": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string"
+                        },
+                        "metadata": {
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            },
+                            "creationTimestamp": {
+                              "type": "string"
+                            },
+                            "deletionGracePeriodSeconds": {
+                              "type": "integer"
+                            },
+                            "deletionTimestamp": {
+                              "type": "string"
+                            },
+                            "finalizers": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "generateName": {
+                              "type": "string"
+                            },
+                            "generation": {
+                              "type": "integer"
+                            },
+                            "labels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            },
+                            "managedFields": {
+                              "items": {
+                                "properties": {
+                                  "apiVersion": {
+                                    "type": "string"
+                                  },
+                                  "fieldsType": {
+                                    "type": "string"
+                                  },
+                                  "fieldsV1": {
+                                    "type": "object"
+                                  },
+                                  "manager": {
+                                    "type": "string"
+                                  },
+                                  "operation": {
+                                    "type": "string"
+                                  },
+                                  "subresource": {
+                                    "type": "string"
+                                  },
+                                  "time": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "type": "string"
+                            },
+                            "ownerReferences": {
+                              "items": {
+                                "properties": {
+                                  "apiVersion": {
+                                    "type": "string"
+                                  },
+                                  "blockOwnerDeletion": {
+                                    "type": "boolean"
+                                  },
+                                  "controller": {
+                                    "type": "boolean"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "uid": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "resourceVersion": {
+                              "type": "string"
+                            },
+                            "selfLink": {
+                              "type": "string"
+                            },
+                            "uid": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "spec": {
+                          "properties": {
+                            "activeDeadlineSeconds": {
+                              "type": "integer"
+                            },
+                            "affinity": {
+                              "properties": {
+                                "nodeAffinity": {
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "items": {
+                                        "properties": {
+                                          "preference": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchFields": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "properties": {
+                                        "nodeSelectorTerms": {
+                                          "items": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchFields": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "podAffinity": {
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "items": {
+                                        "properties": {
+                                          "podAffinityTerm": {
+                                            "properties": {
+                                              "labelSelector": {
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "matchLabelKeys": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "mismatchLabelKeys": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namespaceSelector": {
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaces": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "topologyKey": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "items": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "podAntiAffinity": {
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "items": {
+                                        "properties": {
+                                          "podAffinityTerm": {
+                                            "properties": {
+                                              "labelSelector": {
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "matchLabelKeys": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "mismatchLabelKeys": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namespaceSelector": {
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaces": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "topologyKey": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "items": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "automountServiceAccountToken": {
+                              "type": "boolean"
+                            },
+                            "containers": {
+                              "items": {
+                                "properties": {
+                                  "args": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "env": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "valueFrom": {
+                                          "properties": {
+                                            "configMapKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "fieldRef": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldPath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "resourceFieldRef": {
+                                              "properties": {
+                                                "containerName": {
+                                                  "type": "string"
+                                                },
+                                                "divisor": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "resource": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "secretKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "envFrom": {
+                                    "items": {
+                                      "properties": {
+                                        "configMapRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "prefix": {
+                                          "type": "string"
+                                        },
+                                        "secretRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imagePullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "lifecycle": {
+                                    "properties": {
+                                      "postStart": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "preStop": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "stopSignal": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "livenessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ports": {
+                                    "items": {
+                                      "properties": {
+                                        "containerPort": {
+                                          "type": "integer"
+                                        },
+                                        "hostIP": {
+                                          "type": "string"
+                                        },
+                                        "hostPort": {
+                                          "type": "integer"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "protocol": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "readinessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "resizePolicy": {
+                                    "items": {
+                                      "properties": {
+                                        "resourceName": {
+                                          "type": "string"
+                                        },
+                                        "restartPolicy": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartPolicy": {
+                                    "type": "string"
+                                  },
+                                  "securityContext": {
+                                    "properties": {
+                                      "allowPrivilegeEscalation": {
+                                        "type": "boolean"
+                                      },
+                                      "appArmorProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "capabilities": {
+                                        "properties": {
+                                          "add": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "drop": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "privileged": {
+                                        "type": "boolean"
+                                      },
+                                      "procMount": {
+                                        "type": "string"
+                                      },
+                                      "readOnlyRootFilesystem": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsGroup": {
+                                        "type": "integer"
+                                      },
+                                      "runAsNonRoot": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUser": {
+                                        "type": "integer"
+                                      },
+                                      "seLinuxOptions": {
+                                        "properties": {
+                                          "level": {
+                                            "type": "string"
+                                          },
+                                          "role": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          },
+                                          "user": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "seccompProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "windowsOptions": {
+                                        "properties": {
+                                          "gmsaCredentialSpec": {
+                                            "type": "string"
+                                          },
+                                          "gmsaCredentialSpecName": {
+                                            "type": "string"
+                                          },
+                                          "hostProcess": {
+                                            "type": "boolean"
+                                          },
+                                          "runAsUserName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "startupProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stdin": {
+                                    "type": "boolean"
+                                  },
+                                  "stdinOnce": {
+                                    "type": "boolean"
+                                  },
+                                  "terminationMessagePath": {
+                                    "type": "string"
+                                  },
+                                  "terminationMessagePolicy": {
+                                    "type": "string"
+                                  },
+                                  "tty": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeDevices": {
+                                    "items": {
+                                      "properties": {
+                                        "devicePath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "mountPropagation": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        },
+                                        "subPath": {
+                                          "type": "string"
+                                        },
+                                        "subPathExpr": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "workingDir": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "dnsConfig": {
+                              "properties": {
+                                "nameservers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "options": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "searches": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "dnsPolicy": {
+                              "type": "string"
+                            },
+                            "enableServiceLinks": {
+                              "type": "boolean"
+                            },
+                            "ephemeralContainers": {
+                              "items": {
+                                "properties": {
+                                  "args": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "env": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "valueFrom": {
+                                          "properties": {
+                                            "configMapKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "fieldRef": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldPath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "resourceFieldRef": {
+                                              "properties": {
+                                                "containerName": {
+                                                  "type": "string"
+                                                },
+                                                "divisor": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "resource": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "secretKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "envFrom": {
+                                    "items": {
+                                      "properties": {
+                                        "configMapRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "prefix": {
+                                          "type": "string"
+                                        },
+                                        "secretRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imagePullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "lifecycle": {
+                                    "properties": {
+                                      "postStart": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "preStop": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "stopSignal": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "livenessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ports": {
+                                    "items": {
+                                      "properties": {
+                                        "containerPort": {
+                                          "type": "integer"
+                                        },
+                                        "hostIP": {
+                                          "type": "string"
+                                        },
+                                        "hostPort": {
+                                          "type": "integer"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "protocol": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "readinessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "resizePolicy": {
+                                    "items": {
+                                      "properties": {
+                                        "resourceName": {
+                                          "type": "string"
+                                        },
+                                        "restartPolicy": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartPolicy": {
+                                    "type": "string"
+                                  },
+                                  "securityContext": {
+                                    "properties": {
+                                      "allowPrivilegeEscalation": {
+                                        "type": "boolean"
+                                      },
+                                      "appArmorProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "capabilities": {
+                                        "properties": {
+                                          "add": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "drop": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "privileged": {
+                                        "type": "boolean"
+                                      },
+                                      "procMount": {
+                                        "type": "string"
+                                      },
+                                      "readOnlyRootFilesystem": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsGroup": {
+                                        "type": "integer"
+                                      },
+                                      "runAsNonRoot": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUser": {
+                                        "type": "integer"
+                                      },
+                                      "seLinuxOptions": {
+                                        "properties": {
+                                          "level": {
+                                            "type": "string"
+                                          },
+                                          "role": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          },
+                                          "user": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "seccompProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "windowsOptions": {
+                                        "properties": {
+                                          "gmsaCredentialSpec": {
+                                            "type": "string"
+                                          },
+                                          "gmsaCredentialSpecName": {
+                                            "type": "string"
+                                          },
+                                          "hostProcess": {
+                                            "type": "boolean"
+                                          },
+                                          "runAsUserName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "startupProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stdin": {
+                                    "type": "boolean"
+                                  },
+                                  "stdinOnce": {
+                                    "type": "boolean"
+                                  },
+                                  "targetContainerName": {
+                                    "type": "string"
+                                  },
+                                  "terminationMessagePath": {
+                                    "type": "string"
+                                  },
+                                  "terminationMessagePolicy": {
+                                    "type": "string"
+                                  },
+                                  "tty": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeDevices": {
+                                    "items": {
+                                      "properties": {
+                                        "devicePath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "mountPropagation": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        },
+                                        "subPath": {
+                                          "type": "string"
+                                        },
+                                        "subPathExpr": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "workingDir": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "hostAliases": {
+                              "items": {
+                                "properties": {
+                                  "hostnames": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ip": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "hostIPC": {
+                              "type": "boolean"
+                            },
+                            "hostNetwork": {
+                              "type": "boolean"
+                            },
+                            "hostPID": {
+                              "type": "boolean"
+                            },
+                            "hostUsers": {
+                              "type": "boolean"
+                            },
+                            "hostname": {
+                              "type": "string"
+                            },
+                            "imagePullSecrets": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "initContainers": {
+                              "items": {
+                                "properties": {
+                                  "args": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "env": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "valueFrom": {
+                                          "properties": {
+                                            "configMapKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "fieldRef": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldPath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "resourceFieldRef": {
+                                              "properties": {
+                                                "containerName": {
+                                                  "type": "string"
+                                                },
+                                                "divisor": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "resource": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "secretKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "envFrom": {
+                                    "items": {
+                                      "properties": {
+                                        "configMapRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "prefix": {
+                                          "type": "string"
+                                        },
+                                        "secretRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imagePullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "lifecycle": {
+                                    "properties": {
+                                      "postStart": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "preStop": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "stopSignal": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "livenessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ports": {
+                                    "items": {
+                                      "properties": {
+                                        "containerPort": {
+                                          "type": "integer"
+                                        },
+                                        "hostIP": {
+                                          "type": "string"
+                                        },
+                                        "hostPort": {
+                                          "type": "integer"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "protocol": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "readinessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "resizePolicy": {
+                                    "items": {
+                                      "properties": {
+                                        "resourceName": {
+                                          "type": "string"
+                                        },
+                                        "restartPolicy": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartPolicy": {
+                                    "type": "string"
+                                  },
+                                  "securityContext": {
+                                    "properties": {
+                                      "allowPrivilegeEscalation": {
+                                        "type": "boolean"
+                                      },
+                                      "appArmorProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "capabilities": {
+                                        "properties": {
+                                          "add": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "drop": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "privileged": {
+                                        "type": "boolean"
+                                      },
+                                      "procMount": {
+                                        "type": "string"
+                                      },
+                                      "readOnlyRootFilesystem": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsGroup": {
+                                        "type": "integer"
+                                      },
+                                      "runAsNonRoot": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUser": {
+                                        "type": "integer"
+                                      },
+                                      "seLinuxOptions": {
+                                        "properties": {
+                                          "level": {
+                                            "type": "string"
+                                          },
+                                          "role": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          },
+                                          "user": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "seccompProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "windowsOptions": {
+                                        "properties": {
+                                          "gmsaCredentialSpec": {
+                                            "type": "string"
+                                          },
+                                          "gmsaCredentialSpecName": {
+                                            "type": "string"
+                                          },
+                                          "hostProcess": {
+                                            "type": "boolean"
+                                          },
+                                          "runAsUserName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "startupProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stdin": {
+                                    "type": "boolean"
+                                  },
+                                  "stdinOnce": {
+                                    "type": "boolean"
+                                  },
+                                  "terminationMessagePath": {
+                                    "type": "string"
+                                  },
+                                  "terminationMessagePolicy": {
+                                    "type": "string"
+                                  },
+                                  "tty": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeDevices": {
+                                    "items": {
+                                      "properties": {
+                                        "devicePath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "mountPropagation": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        },
+                                        "subPath": {
+                                          "type": "string"
+                                        },
+                                        "subPathExpr": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "workingDir": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "nodeName": {
+                              "type": "string"
+                            },
+                            "nodeSelector": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            },
+                            "os": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "overhead": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "preemptionPolicy": {
+                              "type": "string"
+                            },
+                            "priority": {
+                              "type": "integer"
+                            },
+                            "priorityClassName": {
+                              "type": "string"
+                            },
+                            "readinessGates": {
+                              "items": {
+                                "properties": {
+                                  "conditionType": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "resourceClaims": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resourceClaimName": {
+                                    "type": "string"
+                                  },
+                                  "resourceClaimTemplateName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "restartPolicy": {
+                              "type": "string"
+                            },
+                            "runtimeClassName": {
+                              "type": "string"
+                            },
+                            "schedulerName": {
+                              "type": "string"
+                            },
+                            "schedulingGates": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "securityContext": {
+                              "properties": {
+                                "appArmorProfile": {
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "fsGroup": {
+                                  "type": "integer"
+                                },
+                                "fsGroupChangePolicy": {
+                                  "type": "string"
+                                },
+                                "runAsGroup": {
+                                  "type": "integer"
+                                },
+                                "runAsNonRoot": {
+                                  "type": "boolean"
+                                },
+                                "runAsUser": {
+                                  "type": "integer"
+                                },
+                                "seLinuxChangePolicy": {
+                                  "type": "string"
+                                },
+                                "seLinuxOptions": {
+                                  "properties": {
+                                    "level": {
+                                      "type": "string"
+                                    },
+                                    "role": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    },
+                                    "user": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "seccompProfile": {
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "supplementalGroups": {
+                                  "items": {
+                                    "type": "integer"
+                                  },
+                                  "type": "array"
+                                },
+                                "supplementalGroupsPolicy": {
+                                  "type": "string"
+                                },
+                                "sysctls": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "windowsOptions": {
+                                  "properties": {
+                                    "gmsaCredentialSpec": {
+                                      "type": "string"
+                                    },
+                                    "gmsaCredentialSpecName": {
+                                      "type": "string"
+                                    },
+                                    "hostProcess": {
+                                      "type": "boolean"
+                                    },
+                                    "runAsUserName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccount": {
+                              "type": "string"
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "setHostnameAsFQDN": {
+                              "type": "boolean"
+                            },
+                            "shareProcessNamespace": {
+                              "type": "boolean"
+                            },
+                            "subdomain": {
+                              "type": "string"
+                            },
+                            "terminationGracePeriodSeconds": {
+                              "type": "integer"
+                            },
+                            "tolerations": {
+                              "items": {
+                                "properties": {
+                                  "effect": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "type": "string"
+                                  },
+                                  "tolerationSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "topologySpreadConstraints": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "maxSkew": {
+                                    "type": "integer"
+                                  },
+                                  "minDomains": {
+                                    "type": "integer"
+                                  },
+                                  "nodeAffinityPolicy": {
+                                    "type": "string"
+                                  },
+                                  "nodeTaintsPolicy": {
+                                    "type": "string"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  },
+                                  "whenUnsatisfiable": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "volumes": {
+                              "items": {
+                                "properties": {
+                                  "awsElasticBlockStore": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "partition": {
+                                        "type": "integer"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "volumeID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "azureDisk": {
+                                    "properties": {
+                                      "cachingMode": {
+                                        "type": "string"
+                                      },
+                                      "diskName": {
+                                        "type": "string"
+                                      },
+                                      "diskURI": {
+                                        "type": "string"
+                                      },
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "azureFile": {
+                                    "properties": {
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretName": {
+                                        "type": "string"
+                                      },
+                                      "shareName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "cephfs": {
+                                    "properties": {
+                                      "monitors": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretFile": {
+                                        "type": "string"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "cinder": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "volumeID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "configMap": {
+                                    "properties": {
+                                      "defaultMode": {
+                                        "type": "integer"
+                                      },
+                                      "items": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "mode": {
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "csi": {
+                                    "properties": {
+                                      "driver": {
+                                        "type": "string"
+                                      },
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "nodePublishSecretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "volumeAttributes": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "downwardAPI": {
+                                    "properties": {
+                                      "defaultMode": {
+                                        "type": "integer"
+                                      },
+                                      "items": {
+                                        "items": {
+                                          "properties": {
+                                            "fieldRef": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldPath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "mode": {
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "resourceFieldRef": {
+                                              "properties": {
+                                                "containerName": {
+                                                  "type": "string"
+                                                },
+                                                "divisor": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "resource": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "emptyDir": {
+                                    "properties": {
+                                      "medium": {
+                                        "type": "string"
+                                      },
+                                      "sizeLimit": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "ephemeral": {
+                                    "properties": {
+                                      "volumeClaimTemplate": {
+                                        "properties": {
+                                          "metadata": {
+                                            "properties": {
+                                              "annotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "creationTimestamp": {
+                                                "type": "string"
+                                              },
+                                              "deletionGracePeriodSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "deletionTimestamp": {
+                                                "type": "string"
+                                              },
+                                              "finalizers": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "generateName": {
+                                                "type": "string"
+                                              },
+                                              "generation": {
+                                                "type": "integer"
+                                              },
+                                              "labels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "managedFields": {
+                                                "items": {
+                                                  "properties": {
+                                                    "apiVersion": {
+                                                      "type": "string"
+                                                    },
+                                                    "fieldsType": {
+                                                      "type": "string"
+                                                    },
+                                                    "fieldsV1": {
+                                                      "type": "object"
+                                                    },
+                                                    "manager": {
+                                                      "type": "string"
+                                                    },
+                                                    "operation": {
+                                                      "type": "string"
+                                                    },
+                                                    "subresource": {
+                                                      "type": "string"
+                                                    },
+                                                    "time": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "ownerReferences": {
+                                                "items": {
+                                                  "properties": {
+                                                    "apiVersion": {
+                                                      "type": "string"
+                                                    },
+                                                    "blockOwnerDeletion": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "controller": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "kind": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "uid": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "resourceVersion": {
+                                                "type": "string"
+                                              },
+                                              "selfLink": {
+                                                "type": "string"
+                                              },
+                                              "uid": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "spec": {
+                                            "properties": {
+                                              "accessModes": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "dataSource": {
+                                                "properties": {
+                                                  "apiGroup": {
+                                                    "type": "string"
+                                                  },
+                                                  "kind": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "dataSourceRef": {
+                                                "properties": {
+                                                  "apiGroup": {
+                                                    "type": "string"
+                                                  },
+                                                  "kind": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "namespace": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "resources": {
+                                                "properties": {
+                                                  "limits": {
+                                                    "additionalProperties": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "requests": {
+                                                    "additionalProperties": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "selector": {
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "storageClassName": {
+                                                "type": "string"
+                                              },
+                                              "volumeAttributesClassName": {
+                                                "type": "string"
+                                              },
+                                              "volumeMode": {
+                                                "type": "string"
+                                              },
+                                              "volumeName": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "fc": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "lun": {
+                                        "type": "integer"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "targetWWNs": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "wwids": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "flexVolume": {
+                                    "properties": {
+                                      "driver": {
+                                        "type": "string"
+                                      },
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "options": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "flocker": {
+                                    "properties": {
+                                      "datasetName": {
+                                        "type": "string"
+                                      },
+                                      "datasetUUID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "gcePersistentDisk": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "partition": {
+                                        "type": "integer"
+                                      },
+                                      "pdName": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "gitRepo": {
+                                    "properties": {
+                                      "directory": {
+                                        "type": "string"
+                                      },
+                                      "repository": {
+                                        "type": "string"
+                                      },
+                                      "revision": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "glusterfs": {
+                                    "properties": {
+                                      "endpoints": {
+                                        "type": "string"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "hostPath": {
+                                    "properties": {
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "image": {
+                                    "properties": {
+                                      "pullPolicy": {
+                                        "type": "string"
+                                      },
+                                      "reference": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "iscsi": {
+                                    "properties": {
+                                      "chapAuthDiscovery": {
+                                        "type": "boolean"
+                                      },
+                                      "chapAuthSession": {
+                                        "type": "boolean"
+                                      },
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "initiatorName": {
+                                        "type": "string"
+                                      },
+                                      "iqn": {
+                                        "type": "string"
+                                      },
+                                      "iscsiInterface": {
+                                        "type": "string"
+                                      },
+                                      "lun": {
+                                        "type": "integer"
+                                      },
+                                      "portals": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "targetPortal": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "nfs": {
+                                    "properties": {
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "server": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "persistentVolumeClaim": {
+                                    "properties": {
+                                      "claimName": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "photonPersistentDisk": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "pdID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "portworxVolume": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "volumeID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "projected": {
+                                    "properties": {
+                                      "defaultMode": {
+                                        "type": "integer"
+                                      },
+                                      "sources": {
+                                        "items": {
+                                          "properties": {
+                                            "clusterTrustBundle": {
+                                              "properties": {
+                                                "labelSelector": {
+                                                  "properties": {
+                                                    "matchExpressions": {
+                                                      "items": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "operator": {
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "matchLabels": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                },
+                                                "path": {
+                                                  "type": "string"
+                                                },
+                                                "signerName": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "configMap": {
+                                              "properties": {
+                                                "items": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "mode": {
+                                                        "type": "integer"
+                                                      },
+                                                      "path": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "downwardAPI": {
+                                              "properties": {
+                                                "items": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "fieldRef": {
+                                                        "properties": {
+                                                          "apiVersion": {
+                                                            "type": "string"
+                                                          },
+                                                          "fieldPath": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "mode": {
+                                                        "type": "integer"
+                                                      },
+                                                      "path": {
+                                                        "type": "string"
+                                                      },
+                                                      "resourceFieldRef": {
+                                                        "properties": {
+                                                          "containerName": {
+                                                            "type": "string"
+                                                          },
+                                                          "divisor": {
+                                                            "anyOf": [
+                                                              {
+                                                                "type": "integer"
+                                                              },
+                                                              {
+                                                                "type": "string"
+                                                              }
+                                                            ],
+                                                            "x-kubernetes-int-or-string": true
+                                                          },
+                                                          "resource": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "secret": {
+                                              "properties": {
+                                                "items": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "mode": {
+                                                        "type": "integer"
+                                                      },
+                                                      "path": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "serviceAccountToken": {
+                                              "properties": {
+                                                "audience": {
+                                                  "type": "string"
+                                                },
+                                                "expirationSeconds": {
+                                                  "type": "integer"
+                                                },
+                                                "path": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "quobyte": {
+                                    "properties": {
+                                      "group": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "registry": {
+                                        "type": "string"
+                                      },
+                                      "tenant": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      },
+                                      "volume": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "rbd": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "image": {
+                                        "type": "string"
+                                      },
+                                      "keyring": {
+                                        "type": "string"
+                                      },
+                                      "monitors": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "pool": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "scaleIO": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "gateway": {
+                                        "type": "string"
+                                      },
+                                      "protectionDomain": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sslEnabled": {
+                                        "type": "boolean"
+                                      },
+                                      "storageMode": {
+                                        "type": "string"
+                                      },
+                                      "storagePool": {
+                                        "type": "string"
+                                      },
+                                      "system": {
+                                        "type": "string"
+                                      },
+                                      "volumeName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "secret": {
+                                    "properties": {
+                                      "defaultMode": {
+                                        "type": "integer"
+                                      },
+                                      "items": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "mode": {
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      },
+                                      "secretName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "storageos": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "volumeName": {
+                                        "type": "string"
+                                      },
+                                      "volumeNamespace": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "vsphereVolume": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "storagePolicyID": {
+                                        "type": "string"
+                                      },
+                                      "storagePolicyName": {
+                                        "type": "string"
+                                      },
+                                      "volumePath": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "status": {
+                          "properties": {
+                            "conditions": {
+                              "items": {
+                                "properties": {
+                                  "lastProbeTime": {
+                                    "type": "string"
+                                  },
+                                  "lastTransitionTime": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "observedGeneration": {
+                                    "type": "integer"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "status": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "containerStatuses": {
+                              "items": {
+                                "properties": {
+                                  "allocatedResources": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "allocatedResourcesStatus": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "resources": {
+                                          "items": {
+                                            "properties": {
+                                              "health": {
+                                                "type": "string"
+                                              },
+                                              "resourceID": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imageID": {
+                                    "type": "string"
+                                  },
+                                  "lastState": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ready": {
+                                    "type": "boolean"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartCount": {
+                                    "type": "integer"
+                                  },
+                                  "started": {
+                                    "type": "boolean"
+                                  },
+                                  "state": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "properties": {
+                                      "linux": {
+                                        "properties": {
+                                          "gid": {
+                                            "type": "integer"
+                                          },
+                                          "supplementalGroups": {
+                                            "items": {
+                                              "type": "integer"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "uid": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "ephemeralContainerStatuses": {
+                              "items": {
+                                "properties": {
+                                  "allocatedResources": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "allocatedResourcesStatus": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "resources": {
+                                          "items": {
+                                            "properties": {
+                                              "health": {
+                                                "type": "string"
+                                              },
+                                              "resourceID": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imageID": {
+                                    "type": "string"
+                                  },
+                                  "lastState": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ready": {
+                                    "type": "boolean"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartCount": {
+                                    "type": "integer"
+                                  },
+                                  "started": {
+                                    "type": "boolean"
+                                  },
+                                  "state": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "properties": {
+                                      "linux": {
+                                        "properties": {
+                                          "gid": {
+                                            "type": "integer"
+                                          },
+                                          "supplementalGroups": {
+                                            "items": {
+                                              "type": "integer"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "uid": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostIPs": {
+                              "items": {
+                                "properties": {
+                                  "ip": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "initContainerStatuses": {
+                              "items": {
+                                "properties": {
+                                  "allocatedResources": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "allocatedResourcesStatus": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "resources": {
+                                          "items": {
+                                            "properties": {
+                                              "health": {
+                                                "type": "string"
+                                              },
+                                              "resourceID": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imageID": {
+                                    "type": "string"
+                                  },
+                                  "lastState": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ready": {
+                                    "type": "boolean"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartCount": {
+                                    "type": "integer"
+                                  },
+                                  "started": {
+                                    "type": "boolean"
+                                  },
+                                  "state": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "properties": {
+                                      "linux": {
+                                        "properties": {
+                                          "gid": {
+                                            "type": "integer"
+                                          },
+                                          "supplementalGroups": {
+                                            "items": {
+                                              "type": "integer"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "uid": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "message": {
+                              "type": "string"
+                            },
+                            "nominatedNodeName": {
+                              "type": "string"
+                            },
+                            "observedGeneration": {
+                              "type": "integer"
+                            },
+                            "phase": {
+                              "type": "string"
+                            },
+                            "podIP": {
+                              "type": "string"
+                            },
+                            "podIPs": {
+                              "items": {
+                                "properties": {
+                                  "ip": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "qosClass": {
+                              "type": "string"
+                            },
+                            "reason": {
+                              "type": "string"
+                            },
+                            "resize": {
+                              "type": "string"
+                            },
+                            "resourceClaimStatuses": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resourceClaimName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "startTime": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "replicas": {
+                      "type": "integer"
+                    },
+                    "resource": {
+                      "properties": {
+                        "cpu": {
+                          "type": "number"
+                        },
+                        "ephemeralStorage": {
+                          "type": "string"
+                        },
+                        "memory": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "logConfiguration": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "mode": {
+                  "enum": [
+                    "native",
+                    "standalone"
+                  ],
+                  "type": "string"
+                },
+                "podTemplate": {
+                  "properties": {
+                    "apiVersion": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "metadata": {
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "creationTimestamp": {
+                          "type": "string"
+                        },
+                        "deletionGracePeriodSeconds": {
+                          "type": "integer"
+                        },
+                        "deletionTimestamp": {
+                          "type": "string"
+                        },
+                        "finalizers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "generateName": {
+                          "type": "string"
+                        },
+                        "generation": {
+                          "type": "integer"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "managedFields": {
+                          "items": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "fieldsType": {
+                                "type": "string"
+                              },
+                              "fieldsV1": {
+                                "type": "object"
+                              },
+                              "manager": {
+                                "type": "string"
+                              },
+                              "operation": {
+                                "type": "string"
+                              },
+                              "subresource": {
+                                "type": "string"
+                              },
+                              "time": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        },
+                        "ownerReferences": {
+                          "items": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "blockOwnerDeletion": {
+                                "type": "boolean"
+                              },
+                              "controller": {
+                                "type": "boolean"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "uid": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "resourceVersion": {
+                          "type": "string"
+                        },
+                        "selfLink": {
+                          "type": "string"
+                        },
+                        "uid": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "spec": {
+                      "properties": {
+                        "activeDeadlineSeconds": {
+                          "type": "integer"
+                        },
+                        "affinity": {
+                          "properties": {
+                            "nodeAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "preference": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "properties": {
+                                    "nodeSelectorTerms": {
+                                      "items": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "podAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "podAntiAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "automountServiceAccountToken": {
+                          "type": "boolean"
+                        },
+                        "containers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "dnsConfig": {
+                          "properties": {
+                            "nameservers": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "options": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "searches": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "dnsPolicy": {
+                          "type": "string"
+                        },
+                        "enableServiceLinks": {
+                          "type": "boolean"
+                        },
+                        "ephemeralContainers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "targetContainerName": {
+                                "type": "string"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "hostAliases": {
+                          "items": {
+                            "properties": {
+                              "hostnames": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "ip": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "hostIPC": {
+                          "type": "boolean"
+                        },
+                        "hostNetwork": {
+                          "type": "boolean"
+                        },
+                        "hostPID": {
+                          "type": "boolean"
+                        },
+                        "hostUsers": {
+                          "type": "boolean"
+                        },
+                        "hostname": {
+                          "type": "string"
+                        },
+                        "imagePullSecrets": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "initContainers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "nodeName": {
+                          "type": "string"
+                        },
+                        "nodeSelector": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "os": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "overhead": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "preemptionPolicy": {
+                          "type": "string"
+                        },
+                        "priority": {
+                          "type": "integer"
+                        },
+                        "priorityClassName": {
+                          "type": "string"
+                        },
+                        "readinessGates": {
+                          "items": {
+                            "properties": {
+                              "conditionType": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "resourceClaims": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "resourceClaimName": {
+                                "type": "string"
+                              },
+                              "resourceClaimTemplateName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "resources": {
+                          "properties": {
+                            "claims": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "restartPolicy": {
+                          "type": "string"
+                        },
+                        "runtimeClassName": {
+                          "type": "string"
+                        },
+                        "schedulerName": {
+                          "type": "string"
+                        },
+                        "schedulingGates": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "securityContext": {
+                          "properties": {
+                            "appArmorProfile": {
+                              "properties": {
+                                "localhostProfile": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "fsGroup": {
+                              "type": "integer"
+                            },
+                            "fsGroupChangePolicy": {
+                              "type": "string"
+                            },
+                            "runAsGroup": {
+                              "type": "integer"
+                            },
+                            "runAsNonRoot": {
+                              "type": "boolean"
+                            },
+                            "runAsUser": {
+                              "type": "integer"
+                            },
+                            "seLinuxChangePolicy": {
+                              "type": "string"
+                            },
+                            "seLinuxOptions": {
+                              "properties": {
+                                "level": {
+                                  "type": "string"
+                                },
+                                "role": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                },
+                                "user": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "seccompProfile": {
+                              "properties": {
+                                "localhostProfile": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "supplementalGroups": {
+                              "items": {
+                                "type": "integer"
+                              },
+                              "type": "array"
+                            },
+                            "supplementalGroupsPolicy": {
+                              "type": "string"
+                            },
+                            "sysctls": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "windowsOptions": {
+                              "properties": {
+                                "gmsaCredentialSpec": {
+                                  "type": "string"
+                                },
+                                "gmsaCredentialSpecName": {
+                                  "type": "string"
+                                },
+                                "hostProcess": {
+                                  "type": "boolean"
+                                },
+                                "runAsUserName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "serviceAccount": {
+                          "type": "string"
+                        },
+                        "serviceAccountName": {
+                          "type": "string"
+                        },
+                        "setHostnameAsFQDN": {
+                          "type": "boolean"
+                        },
+                        "shareProcessNamespace": {
+                          "type": "boolean"
+                        },
+                        "subdomain": {
+                          "type": "string"
+                        },
+                        "terminationGracePeriodSeconds": {
+                          "type": "integer"
+                        },
+                        "tolerations": {
+                          "items": {
+                            "properties": {
+                              "effect": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "operator": {
+                                "type": "string"
+                              },
+                              "tolerationSeconds": {
+                                "type": "integer"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "topologySpreadConstraints": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "maxSkew": {
+                                "type": "integer"
+                              },
+                              "minDomains": {
+                                "type": "integer"
+                              },
+                              "nodeAffinityPolicy": {
+                                "type": "string"
+                              },
+                              "nodeTaintsPolicy": {
+                                "type": "string"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              },
+                              "whenUnsatisfiable": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "volumes": {
+                          "items": {
+                            "properties": {
+                              "awsElasticBlockStore": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "partition": {
+                                    "type": "integer"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "azureDisk": {
+                                "properties": {
+                                  "cachingMode": {
+                                    "type": "string"
+                                  },
+                                  "diskName": {
+                                    "type": "string"
+                                  },
+                                  "diskURI": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "azureFile": {
+                                "properties": {
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretName": {
+                                    "type": "string"
+                                  },
+                                  "shareName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "cephfs": {
+                                "properties": {
+                                  "monitors": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretFile": {
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "cinder": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "configMap": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "csi": {
+                                "properties": {
+                                  "driver": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "nodePublishSecretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeAttributes": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "downwardAPI": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "emptyDir": {
+                                "properties": {
+                                  "medium": {
+                                    "type": "string"
+                                  },
+                                  "sizeLimit": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "ephemeral": {
+                                "properties": {
+                                  "volumeClaimTemplate": {
+                                    "properties": {
+                                      "metadata": {
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "creationTimestamp": {
+                                            "type": "string"
+                                          },
+                                          "deletionGracePeriodSeconds": {
+                                            "type": "integer"
+                                          },
+                                          "deletionTimestamp": {
+                                            "type": "string"
+                                          },
+                                          "finalizers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "generateName": {
+                                            "type": "string"
+                                          },
+                                          "generation": {
+                                            "type": "integer"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "managedFields": {
+                                            "items": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldsType": {
+                                                  "type": "string"
+                                                },
+                                                "fieldsV1": {
+                                                  "type": "object"
+                                                },
+                                                "manager": {
+                                                  "type": "string"
+                                                },
+                                                "operation": {
+                                                  "type": "string"
+                                                },
+                                                "subresource": {
+                                                  "type": "string"
+                                                },
+                                                "time": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          },
+                                          "ownerReferences": {
+                                            "items": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "blockOwnerDeletion": {
+                                                  "type": "boolean"
+                                                },
+                                                "controller": {
+                                                  "type": "boolean"
+                                                },
+                                                "kind": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "uid": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "resourceVersion": {
+                                            "type": "string"
+                                          },
+                                          "selfLink": {
+                                            "type": "string"
+                                          },
+                                          "uid": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "spec": {
+                                        "properties": {
+                                          "accessModes": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "dataSource": {
+                                            "properties": {
+                                              "apiGroup": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "dataSourceRef": {
+                                            "properties": {
+                                              "apiGroup": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "resources": {
+                                            "properties": {
+                                              "limits": {
+                                                "additionalProperties": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "type": "object"
+                                              },
+                                              "requests": {
+                                                "additionalProperties": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "selector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "storageClassName": {
+                                            "type": "string"
+                                          },
+                                          "volumeAttributesClassName": {
+                                            "type": "string"
+                                          },
+                                          "volumeMode": {
+                                            "type": "string"
+                                          },
+                                          "volumeName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "fc": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "lun": {
+                                    "type": "integer"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "targetWWNs": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "wwids": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "flexVolume": {
+                                "properties": {
+                                  "driver": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "options": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "flocker": {
+                                "properties": {
+                                  "datasetName": {
+                                    "type": "string"
+                                  },
+                                  "datasetUUID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "gcePersistentDisk": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "partition": {
+                                    "type": "integer"
+                                  },
+                                  "pdName": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "gitRepo": {
+                                "properties": {
+                                  "directory": {
+                                    "type": "string"
+                                  },
+                                  "repository": {
+                                    "type": "string"
+                                  },
+                                  "revision": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "glusterfs": {
+                                "properties": {
+                                  "endpoints": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "hostPath": {
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "image": {
+                                "properties": {
+                                  "pullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "reference": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "iscsi": {
+                                "properties": {
+                                  "chapAuthDiscovery": {
+                                    "type": "boolean"
+                                  },
+                                  "chapAuthSession": {
+                                    "type": "boolean"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "initiatorName": {
+                                    "type": "string"
+                                  },
+                                  "iqn": {
+                                    "type": "string"
+                                  },
+                                  "iscsiInterface": {
+                                    "type": "string"
+                                  },
+                                  "lun": {
+                                    "type": "integer"
+                                  },
+                                  "portals": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "targetPortal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "nfs": {
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "server": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "persistentVolumeClaim": {
+                                "properties": {
+                                  "claimName": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "photonPersistentDisk": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "pdID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "portworxVolume": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "projected": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "sources": {
+                                    "items": {
+                                      "properties": {
+                                        "clusterTrustBundle": {
+                                          "properties": {
+                                            "labelSelector": {
+                                              "properties": {
+                                                "matchExpressions": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "matchLabels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "signerName": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "configMap": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "downwardAPI": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "fieldRef": {
+                                                    "properties": {
+                                                      "apiVersion": {
+                                                        "type": "string"
+                                                      },
+                                                      "fieldPath": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "resourceFieldRef": {
+                                                    "properties": {
+                                                      "containerName": {
+                                                        "type": "string"
+                                                      },
+                                                      "divisor": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "integer"
+                                                          },
+                                                          {
+                                                            "type": "string"
+                                                          }
+                                                        ],
+                                                        "x-kubernetes-int-or-string": true
+                                                      },
+                                                      "resource": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "secret": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "serviceAccountToken": {
+                                          "properties": {
+                                            "audience": {
+                                              "type": "string"
+                                            },
+                                            "expirationSeconds": {
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "quobyte": {
+                                "properties": {
+                                  "group": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "registry": {
+                                    "type": "string"
+                                  },
+                                  "tenant": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  },
+                                  "volume": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "rbd": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "keyring": {
+                                    "type": "string"
+                                  },
+                                  "monitors": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "pool": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "scaleIO": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "gateway": {
+                                    "type": "string"
+                                  },
+                                  "protectionDomain": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sslEnabled": {
+                                    "type": "boolean"
+                                  },
+                                  "storageMode": {
+                                    "type": "string"
+                                  },
+                                  "storagePool": {
+                                    "type": "string"
+                                  },
+                                  "system": {
+                                    "type": "string"
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "secret": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  },
+                                  "secretName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "storageos": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  },
+                                  "volumeNamespace": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "vsphereVolume": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "storagePolicyID": {
+                                    "type": "string"
+                                  },
+                                  "storagePolicyName": {
+                                    "type": "string"
+                                  },
+                                  "volumePath": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "status": {
+                      "properties": {
+                        "conditions": {
+                          "items": {
+                            "properties": {
+                              "lastProbeTime": {
+                                "type": "string"
+                              },
+                              "lastTransitionTime": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "observedGeneration": {
+                                "type": "integer"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "containerStatuses": {
+                          "items": {
+                            "properties": {
+                              "allocatedResources": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "allocatedResourcesStatus": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "resources": {
+                                      "items": {
+                                        "properties": {
+                                          "health": {
+                                            "type": "string"
+                                          },
+                                          "resourceID": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imageID": {
+                                "type": "string"
+                              },
+                              "lastState": {
+                                "properties": {
+                                  "running": {
+                                    "properties": {
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminated": {
+                                    "properties": {
+                                      "containerID": {
+                                        "type": "string"
+                                      },
+                                      "exitCode": {
+                                        "type": "integer"
+                                      },
+                                      "finishedAt": {
+                                        "type": "string"
+                                      },
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      },
+                                      "signal": {
+                                        "type": "integer"
+                                      },
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "waiting": {
+                                    "properties": {
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ready": {
+                                "type": "boolean"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "restartCount": {
+                                "type": "integer"
+                              },
+                              "started": {
+                                "type": "boolean"
+                              },
+                              "state": {
+                                "properties": {
+                                  "running": {
+                                    "properties": {
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminated": {
+                                    "properties": {
+                                      "containerID": {
+                                        "type": "string"
+                                      },
+                                      "exitCode": {
+                                        "type": "integer"
+                                      },
+                                      "finishedAt": {
+                                        "type": "string"
+                                      },
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      },
+                                      "signal": {
+                                        "type": "integer"
+                                      },
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "waiting": {
+                                    "properties": {
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "properties": {
+                                  "linux": {
+                                    "properties": {
+                                      "gid": {
+                                        "type": "integer"
+                                      },
+                                      "supplementalGroups": {
+                                        "items": {
+                                          "type": "integer"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "uid": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "ephemeralContainerStatuses": {
+                          "items": {
+                            "properties": {
+                              "allocatedResources": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "allocatedResourcesStatus": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "resources": {
+                                      "items": {
+                                        "properties": {
+                                          "health": {
+                                            "type": "string"
+                                          },
+                                          "resourceID": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imageID": {
+                                "type": "string"
+                              },
+                              "lastState": {
+                                "properties": {
+                                  "running": {
+                                    "properties": {
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminated": {
+                                    "properties": {
+                                      "containerID": {
+                                        "type": "string"
+                                      },
+                                      "exitCode": {
+                                        "type": "integer"
+                                      },
+                                      "finishedAt": {
+                                        "type": "string"
+                                      },
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      },
+                                      "signal": {
+                                        "type": "integer"
+                                      },
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "waiting": {
+                                    "properties": {
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ready": {
+                                "type": "boolean"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "restartCount": {
+                                "type": "integer"
+                              },
+                              "started": {
+                                "type": "boolean"
+                              },
+                              "state": {
+                                "properties": {
+                                  "running": {
+                                    "properties": {
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminated": {
+                                    "properties": {
+                                      "containerID": {
+                                        "type": "string"
+                                      },
+                                      "exitCode": {
+                                        "type": "integer"
+                                      },
+                                      "finishedAt": {
+                                        "type": "string"
+                                      },
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      },
+                                      "signal": {
+                                        "type": "integer"
+                                      },
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "waiting": {
+                                    "properties": {
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "properties": {
+                                  "linux": {
+                                    "properties": {
+                                      "gid": {
+                                        "type": "integer"
+                                      },
+                                      "supplementalGroups": {
+                                        "items": {
+                                          "type": "integer"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "uid": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "hostIP": {
+                          "type": "string"
+                        },
+                        "hostIPs": {
+                          "items": {
+                            "properties": {
+                              "ip": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "initContainerStatuses": {
+                          "items": {
+                            "properties": {
+                              "allocatedResources": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "allocatedResourcesStatus": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "resources": {
+                                      "items": {
+                                        "properties": {
+                                          "health": {
+                                            "type": "string"
+                                          },
+                                          "resourceID": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imageID": {
+                                "type": "string"
+                              },
+                              "lastState": {
+                                "properties": {
+                                  "running": {
+                                    "properties": {
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminated": {
+                                    "properties": {
+                                      "containerID": {
+                                        "type": "string"
+                                      },
+                                      "exitCode": {
+                                        "type": "integer"
+                                      },
+                                      "finishedAt": {
+                                        "type": "string"
+                                      },
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      },
+                                      "signal": {
+                                        "type": "integer"
+                                      },
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "waiting": {
+                                    "properties": {
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ready": {
+                                "type": "boolean"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "restartCount": {
+                                "type": "integer"
+                              },
+                              "started": {
+                                "type": "boolean"
+                              },
+                              "state": {
+                                "properties": {
+                                  "running": {
+                                    "properties": {
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminated": {
+                                    "properties": {
+                                      "containerID": {
+                                        "type": "string"
+                                      },
+                                      "exitCode": {
+                                        "type": "integer"
+                                      },
+                                      "finishedAt": {
+                                        "type": "string"
+                                      },
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      },
+                                      "signal": {
+                                        "type": "integer"
+                                      },
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "waiting": {
+                                    "properties": {
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "properties": {
+                                  "linux": {
+                                    "properties": {
+                                      "gid": {
+                                        "type": "integer"
+                                      },
+                                      "supplementalGroups": {
+                                        "items": {
+                                          "type": "integer"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "uid": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "nominatedNodeName": {
+                          "type": "string"
+                        },
+                        "observedGeneration": {
+                          "type": "integer"
+                        },
+                        "phase": {
+                          "type": "string"
+                        },
+                        "podIP": {
+                          "type": "string"
+                        },
+                        "podIPs": {
+                          "items": {
+                            "properties": {
+                              "ip": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "qosClass": {
+                          "type": "string"
+                        },
+                        "reason": {
+                          "type": "string"
+                        },
+                        "resize": {
+                          "type": "string"
+                        },
+                        "resourceClaimStatuses": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "resourceClaimName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "startTime": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "restartNonce": {
+                  "type": "integer"
+                },
+                "serviceAccount": {
+                  "type": "string"
+                },
+                "taskManager": {
+                  "properties": {
+                    "podTemplate": {
+                      "properties": {
+                        "apiVersion": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string"
+                        },
+                        "metadata": {
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            },
+                            "creationTimestamp": {
+                              "type": "string"
+                            },
+                            "deletionGracePeriodSeconds": {
+                              "type": "integer"
+                            },
+                            "deletionTimestamp": {
+                              "type": "string"
+                            },
+                            "finalizers": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "generateName": {
+                              "type": "string"
+                            },
+                            "generation": {
+                              "type": "integer"
+                            },
+                            "labels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            },
+                            "managedFields": {
+                              "items": {
+                                "properties": {
+                                  "apiVersion": {
+                                    "type": "string"
+                                  },
+                                  "fieldsType": {
+                                    "type": "string"
+                                  },
+                                  "fieldsV1": {
+                                    "type": "object"
+                                  },
+                                  "manager": {
+                                    "type": "string"
+                                  },
+                                  "operation": {
+                                    "type": "string"
+                                  },
+                                  "subresource": {
+                                    "type": "string"
+                                  },
+                                  "time": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "type": "string"
+                            },
+                            "ownerReferences": {
+                              "items": {
+                                "properties": {
+                                  "apiVersion": {
+                                    "type": "string"
+                                  },
+                                  "blockOwnerDeletion": {
+                                    "type": "boolean"
+                                  },
+                                  "controller": {
+                                    "type": "boolean"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "uid": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "resourceVersion": {
+                              "type": "string"
+                            },
+                            "selfLink": {
+                              "type": "string"
+                            },
+                            "uid": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "spec": {
+                          "properties": {
+                            "activeDeadlineSeconds": {
+                              "type": "integer"
+                            },
+                            "affinity": {
+                              "properties": {
+                                "nodeAffinity": {
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "items": {
+                                        "properties": {
+                                          "preference": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchFields": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "properties": {
+                                        "nodeSelectorTerms": {
+                                          "items": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchFields": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "podAffinity": {
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "items": {
+                                        "properties": {
+                                          "podAffinityTerm": {
+                                            "properties": {
+                                              "labelSelector": {
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "matchLabelKeys": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "mismatchLabelKeys": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namespaceSelector": {
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaces": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "topologyKey": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "items": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "podAntiAffinity": {
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "items": {
+                                        "properties": {
+                                          "podAffinityTerm": {
+                                            "properties": {
+                                              "labelSelector": {
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "matchLabelKeys": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "mismatchLabelKeys": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namespaceSelector": {
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaces": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "topologyKey": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "items": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "automountServiceAccountToken": {
+                              "type": "boolean"
+                            },
+                            "containers": {
+                              "items": {
+                                "properties": {
+                                  "args": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "env": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "valueFrom": {
+                                          "properties": {
+                                            "configMapKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "fieldRef": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldPath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "resourceFieldRef": {
+                                              "properties": {
+                                                "containerName": {
+                                                  "type": "string"
+                                                },
+                                                "divisor": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "resource": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "secretKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "envFrom": {
+                                    "items": {
+                                      "properties": {
+                                        "configMapRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "prefix": {
+                                          "type": "string"
+                                        },
+                                        "secretRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imagePullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "lifecycle": {
+                                    "properties": {
+                                      "postStart": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "preStop": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "stopSignal": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "livenessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ports": {
+                                    "items": {
+                                      "properties": {
+                                        "containerPort": {
+                                          "type": "integer"
+                                        },
+                                        "hostIP": {
+                                          "type": "string"
+                                        },
+                                        "hostPort": {
+                                          "type": "integer"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "protocol": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "readinessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "resizePolicy": {
+                                    "items": {
+                                      "properties": {
+                                        "resourceName": {
+                                          "type": "string"
+                                        },
+                                        "restartPolicy": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartPolicy": {
+                                    "type": "string"
+                                  },
+                                  "securityContext": {
+                                    "properties": {
+                                      "allowPrivilegeEscalation": {
+                                        "type": "boolean"
+                                      },
+                                      "appArmorProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "capabilities": {
+                                        "properties": {
+                                          "add": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "drop": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "privileged": {
+                                        "type": "boolean"
+                                      },
+                                      "procMount": {
+                                        "type": "string"
+                                      },
+                                      "readOnlyRootFilesystem": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsGroup": {
+                                        "type": "integer"
+                                      },
+                                      "runAsNonRoot": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUser": {
+                                        "type": "integer"
+                                      },
+                                      "seLinuxOptions": {
+                                        "properties": {
+                                          "level": {
+                                            "type": "string"
+                                          },
+                                          "role": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          },
+                                          "user": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "seccompProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "windowsOptions": {
+                                        "properties": {
+                                          "gmsaCredentialSpec": {
+                                            "type": "string"
+                                          },
+                                          "gmsaCredentialSpecName": {
+                                            "type": "string"
+                                          },
+                                          "hostProcess": {
+                                            "type": "boolean"
+                                          },
+                                          "runAsUserName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "startupProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stdin": {
+                                    "type": "boolean"
+                                  },
+                                  "stdinOnce": {
+                                    "type": "boolean"
+                                  },
+                                  "terminationMessagePath": {
+                                    "type": "string"
+                                  },
+                                  "terminationMessagePolicy": {
+                                    "type": "string"
+                                  },
+                                  "tty": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeDevices": {
+                                    "items": {
+                                      "properties": {
+                                        "devicePath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "mountPropagation": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        },
+                                        "subPath": {
+                                          "type": "string"
+                                        },
+                                        "subPathExpr": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "workingDir": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "dnsConfig": {
+                              "properties": {
+                                "nameservers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "options": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "searches": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "dnsPolicy": {
+                              "type": "string"
+                            },
+                            "enableServiceLinks": {
+                              "type": "boolean"
+                            },
+                            "ephemeralContainers": {
+                              "items": {
+                                "properties": {
+                                  "args": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "env": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "valueFrom": {
+                                          "properties": {
+                                            "configMapKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "fieldRef": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldPath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "resourceFieldRef": {
+                                              "properties": {
+                                                "containerName": {
+                                                  "type": "string"
+                                                },
+                                                "divisor": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "resource": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "secretKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "envFrom": {
+                                    "items": {
+                                      "properties": {
+                                        "configMapRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "prefix": {
+                                          "type": "string"
+                                        },
+                                        "secretRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imagePullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "lifecycle": {
+                                    "properties": {
+                                      "postStart": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "preStop": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "stopSignal": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "livenessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ports": {
+                                    "items": {
+                                      "properties": {
+                                        "containerPort": {
+                                          "type": "integer"
+                                        },
+                                        "hostIP": {
+                                          "type": "string"
+                                        },
+                                        "hostPort": {
+                                          "type": "integer"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "protocol": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "readinessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "resizePolicy": {
+                                    "items": {
+                                      "properties": {
+                                        "resourceName": {
+                                          "type": "string"
+                                        },
+                                        "restartPolicy": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartPolicy": {
+                                    "type": "string"
+                                  },
+                                  "securityContext": {
+                                    "properties": {
+                                      "allowPrivilegeEscalation": {
+                                        "type": "boolean"
+                                      },
+                                      "appArmorProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "capabilities": {
+                                        "properties": {
+                                          "add": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "drop": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "privileged": {
+                                        "type": "boolean"
+                                      },
+                                      "procMount": {
+                                        "type": "string"
+                                      },
+                                      "readOnlyRootFilesystem": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsGroup": {
+                                        "type": "integer"
+                                      },
+                                      "runAsNonRoot": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUser": {
+                                        "type": "integer"
+                                      },
+                                      "seLinuxOptions": {
+                                        "properties": {
+                                          "level": {
+                                            "type": "string"
+                                          },
+                                          "role": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          },
+                                          "user": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "seccompProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "windowsOptions": {
+                                        "properties": {
+                                          "gmsaCredentialSpec": {
+                                            "type": "string"
+                                          },
+                                          "gmsaCredentialSpecName": {
+                                            "type": "string"
+                                          },
+                                          "hostProcess": {
+                                            "type": "boolean"
+                                          },
+                                          "runAsUserName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "startupProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stdin": {
+                                    "type": "boolean"
+                                  },
+                                  "stdinOnce": {
+                                    "type": "boolean"
+                                  },
+                                  "targetContainerName": {
+                                    "type": "string"
+                                  },
+                                  "terminationMessagePath": {
+                                    "type": "string"
+                                  },
+                                  "terminationMessagePolicy": {
+                                    "type": "string"
+                                  },
+                                  "tty": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeDevices": {
+                                    "items": {
+                                      "properties": {
+                                        "devicePath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "mountPropagation": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        },
+                                        "subPath": {
+                                          "type": "string"
+                                        },
+                                        "subPathExpr": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "workingDir": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "hostAliases": {
+                              "items": {
+                                "properties": {
+                                  "hostnames": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ip": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "hostIPC": {
+                              "type": "boolean"
+                            },
+                            "hostNetwork": {
+                              "type": "boolean"
+                            },
+                            "hostPID": {
+                              "type": "boolean"
+                            },
+                            "hostUsers": {
+                              "type": "boolean"
+                            },
+                            "hostname": {
+                              "type": "string"
+                            },
+                            "imagePullSecrets": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "initContainers": {
+                              "items": {
+                                "properties": {
+                                  "args": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "env": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "valueFrom": {
+                                          "properties": {
+                                            "configMapKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "fieldRef": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldPath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "resourceFieldRef": {
+                                              "properties": {
+                                                "containerName": {
+                                                  "type": "string"
+                                                },
+                                                "divisor": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "resource": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "secretKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "envFrom": {
+                                    "items": {
+                                      "properties": {
+                                        "configMapRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "prefix": {
+                                          "type": "string"
+                                        },
+                                        "secretRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imagePullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "lifecycle": {
+                                    "properties": {
+                                      "postStart": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "preStop": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "stopSignal": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "livenessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ports": {
+                                    "items": {
+                                      "properties": {
+                                        "containerPort": {
+                                          "type": "integer"
+                                        },
+                                        "hostIP": {
+                                          "type": "string"
+                                        },
+                                        "hostPort": {
+                                          "type": "integer"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "protocol": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "readinessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "resizePolicy": {
+                                    "items": {
+                                      "properties": {
+                                        "resourceName": {
+                                          "type": "string"
+                                        },
+                                        "restartPolicy": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartPolicy": {
+                                    "type": "string"
+                                  },
+                                  "securityContext": {
+                                    "properties": {
+                                      "allowPrivilegeEscalation": {
+                                        "type": "boolean"
+                                      },
+                                      "appArmorProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "capabilities": {
+                                        "properties": {
+                                          "add": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "drop": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "privileged": {
+                                        "type": "boolean"
+                                      },
+                                      "procMount": {
+                                        "type": "string"
+                                      },
+                                      "readOnlyRootFilesystem": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsGroup": {
+                                        "type": "integer"
+                                      },
+                                      "runAsNonRoot": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUser": {
+                                        "type": "integer"
+                                      },
+                                      "seLinuxOptions": {
+                                        "properties": {
+                                          "level": {
+                                            "type": "string"
+                                          },
+                                          "role": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          },
+                                          "user": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "seccompProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "windowsOptions": {
+                                        "properties": {
+                                          "gmsaCredentialSpec": {
+                                            "type": "string"
+                                          },
+                                          "gmsaCredentialSpecName": {
+                                            "type": "string"
+                                          },
+                                          "hostProcess": {
+                                            "type": "boolean"
+                                          },
+                                          "runAsUserName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "startupProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stdin": {
+                                    "type": "boolean"
+                                  },
+                                  "stdinOnce": {
+                                    "type": "boolean"
+                                  },
+                                  "terminationMessagePath": {
+                                    "type": "string"
+                                  },
+                                  "terminationMessagePolicy": {
+                                    "type": "string"
+                                  },
+                                  "tty": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeDevices": {
+                                    "items": {
+                                      "properties": {
+                                        "devicePath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "mountPropagation": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        },
+                                        "subPath": {
+                                          "type": "string"
+                                        },
+                                        "subPathExpr": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "workingDir": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "nodeName": {
+                              "type": "string"
+                            },
+                            "nodeSelector": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            },
+                            "os": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "overhead": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "preemptionPolicy": {
+                              "type": "string"
+                            },
+                            "priority": {
+                              "type": "integer"
+                            },
+                            "priorityClassName": {
+                              "type": "string"
+                            },
+                            "readinessGates": {
+                              "items": {
+                                "properties": {
+                                  "conditionType": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "resourceClaims": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resourceClaimName": {
+                                    "type": "string"
+                                  },
+                                  "resourceClaimTemplateName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "restartPolicy": {
+                              "type": "string"
+                            },
+                            "runtimeClassName": {
+                              "type": "string"
+                            },
+                            "schedulerName": {
+                              "type": "string"
+                            },
+                            "schedulingGates": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "securityContext": {
+                              "properties": {
+                                "appArmorProfile": {
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "fsGroup": {
+                                  "type": "integer"
+                                },
+                                "fsGroupChangePolicy": {
+                                  "type": "string"
+                                },
+                                "runAsGroup": {
+                                  "type": "integer"
+                                },
+                                "runAsNonRoot": {
+                                  "type": "boolean"
+                                },
+                                "runAsUser": {
+                                  "type": "integer"
+                                },
+                                "seLinuxChangePolicy": {
+                                  "type": "string"
+                                },
+                                "seLinuxOptions": {
+                                  "properties": {
+                                    "level": {
+                                      "type": "string"
+                                    },
+                                    "role": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    },
+                                    "user": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "seccompProfile": {
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "supplementalGroups": {
+                                  "items": {
+                                    "type": "integer"
+                                  },
+                                  "type": "array"
+                                },
+                                "supplementalGroupsPolicy": {
+                                  "type": "string"
+                                },
+                                "sysctls": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "windowsOptions": {
+                                  "properties": {
+                                    "gmsaCredentialSpec": {
+                                      "type": "string"
+                                    },
+                                    "gmsaCredentialSpecName": {
+                                      "type": "string"
+                                    },
+                                    "hostProcess": {
+                                      "type": "boolean"
+                                    },
+                                    "runAsUserName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccount": {
+                              "type": "string"
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "setHostnameAsFQDN": {
+                              "type": "boolean"
+                            },
+                            "shareProcessNamespace": {
+                              "type": "boolean"
+                            },
+                            "subdomain": {
+                              "type": "string"
+                            },
+                            "terminationGracePeriodSeconds": {
+                              "type": "integer"
+                            },
+                            "tolerations": {
+                              "items": {
+                                "properties": {
+                                  "effect": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "type": "string"
+                                  },
+                                  "tolerationSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "topologySpreadConstraints": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "maxSkew": {
+                                    "type": "integer"
+                                  },
+                                  "minDomains": {
+                                    "type": "integer"
+                                  },
+                                  "nodeAffinityPolicy": {
+                                    "type": "string"
+                                  },
+                                  "nodeTaintsPolicy": {
+                                    "type": "string"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  },
+                                  "whenUnsatisfiable": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "volumes": {
+                              "items": {
+                                "properties": {
+                                  "awsElasticBlockStore": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "partition": {
+                                        "type": "integer"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "volumeID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "azureDisk": {
+                                    "properties": {
+                                      "cachingMode": {
+                                        "type": "string"
+                                      },
+                                      "diskName": {
+                                        "type": "string"
+                                      },
+                                      "diskURI": {
+                                        "type": "string"
+                                      },
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "azureFile": {
+                                    "properties": {
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretName": {
+                                        "type": "string"
+                                      },
+                                      "shareName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "cephfs": {
+                                    "properties": {
+                                      "monitors": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretFile": {
+                                        "type": "string"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "cinder": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "volumeID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "configMap": {
+                                    "properties": {
+                                      "defaultMode": {
+                                        "type": "integer"
+                                      },
+                                      "items": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "mode": {
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "csi": {
+                                    "properties": {
+                                      "driver": {
+                                        "type": "string"
+                                      },
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "nodePublishSecretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "volumeAttributes": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "downwardAPI": {
+                                    "properties": {
+                                      "defaultMode": {
+                                        "type": "integer"
+                                      },
+                                      "items": {
+                                        "items": {
+                                          "properties": {
+                                            "fieldRef": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldPath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "mode": {
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "resourceFieldRef": {
+                                              "properties": {
+                                                "containerName": {
+                                                  "type": "string"
+                                                },
+                                                "divisor": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "resource": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "emptyDir": {
+                                    "properties": {
+                                      "medium": {
+                                        "type": "string"
+                                      },
+                                      "sizeLimit": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "ephemeral": {
+                                    "properties": {
+                                      "volumeClaimTemplate": {
+                                        "properties": {
+                                          "metadata": {
+                                            "properties": {
+                                              "annotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "creationTimestamp": {
+                                                "type": "string"
+                                              },
+                                              "deletionGracePeriodSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "deletionTimestamp": {
+                                                "type": "string"
+                                              },
+                                              "finalizers": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "generateName": {
+                                                "type": "string"
+                                              },
+                                              "generation": {
+                                                "type": "integer"
+                                              },
+                                              "labels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "managedFields": {
+                                                "items": {
+                                                  "properties": {
+                                                    "apiVersion": {
+                                                      "type": "string"
+                                                    },
+                                                    "fieldsType": {
+                                                      "type": "string"
+                                                    },
+                                                    "fieldsV1": {
+                                                      "type": "object"
+                                                    },
+                                                    "manager": {
+                                                      "type": "string"
+                                                    },
+                                                    "operation": {
+                                                      "type": "string"
+                                                    },
+                                                    "subresource": {
+                                                      "type": "string"
+                                                    },
+                                                    "time": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "ownerReferences": {
+                                                "items": {
+                                                  "properties": {
+                                                    "apiVersion": {
+                                                      "type": "string"
+                                                    },
+                                                    "blockOwnerDeletion": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "controller": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "kind": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "uid": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "resourceVersion": {
+                                                "type": "string"
+                                              },
+                                              "selfLink": {
+                                                "type": "string"
+                                              },
+                                              "uid": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "spec": {
+                                            "properties": {
+                                              "accessModes": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "dataSource": {
+                                                "properties": {
+                                                  "apiGroup": {
+                                                    "type": "string"
+                                                  },
+                                                  "kind": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "dataSourceRef": {
+                                                "properties": {
+                                                  "apiGroup": {
+                                                    "type": "string"
+                                                  },
+                                                  "kind": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "namespace": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "resources": {
+                                                "properties": {
+                                                  "limits": {
+                                                    "additionalProperties": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "requests": {
+                                                    "additionalProperties": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "selector": {
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "storageClassName": {
+                                                "type": "string"
+                                              },
+                                              "volumeAttributesClassName": {
+                                                "type": "string"
+                                              },
+                                              "volumeMode": {
+                                                "type": "string"
+                                              },
+                                              "volumeName": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "fc": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "lun": {
+                                        "type": "integer"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "targetWWNs": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "wwids": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "flexVolume": {
+                                    "properties": {
+                                      "driver": {
+                                        "type": "string"
+                                      },
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "options": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "flocker": {
+                                    "properties": {
+                                      "datasetName": {
+                                        "type": "string"
+                                      },
+                                      "datasetUUID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "gcePersistentDisk": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "partition": {
+                                        "type": "integer"
+                                      },
+                                      "pdName": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "gitRepo": {
+                                    "properties": {
+                                      "directory": {
+                                        "type": "string"
+                                      },
+                                      "repository": {
+                                        "type": "string"
+                                      },
+                                      "revision": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "glusterfs": {
+                                    "properties": {
+                                      "endpoints": {
+                                        "type": "string"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "hostPath": {
+                                    "properties": {
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "image": {
+                                    "properties": {
+                                      "pullPolicy": {
+                                        "type": "string"
+                                      },
+                                      "reference": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "iscsi": {
+                                    "properties": {
+                                      "chapAuthDiscovery": {
+                                        "type": "boolean"
+                                      },
+                                      "chapAuthSession": {
+                                        "type": "boolean"
+                                      },
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "initiatorName": {
+                                        "type": "string"
+                                      },
+                                      "iqn": {
+                                        "type": "string"
+                                      },
+                                      "iscsiInterface": {
+                                        "type": "string"
+                                      },
+                                      "lun": {
+                                        "type": "integer"
+                                      },
+                                      "portals": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "targetPortal": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "nfs": {
+                                    "properties": {
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "server": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "persistentVolumeClaim": {
+                                    "properties": {
+                                      "claimName": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "photonPersistentDisk": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "pdID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "portworxVolume": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "volumeID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "projected": {
+                                    "properties": {
+                                      "defaultMode": {
+                                        "type": "integer"
+                                      },
+                                      "sources": {
+                                        "items": {
+                                          "properties": {
+                                            "clusterTrustBundle": {
+                                              "properties": {
+                                                "labelSelector": {
+                                                  "properties": {
+                                                    "matchExpressions": {
+                                                      "items": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "operator": {
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "matchLabels": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                },
+                                                "path": {
+                                                  "type": "string"
+                                                },
+                                                "signerName": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "configMap": {
+                                              "properties": {
+                                                "items": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "mode": {
+                                                        "type": "integer"
+                                                      },
+                                                      "path": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "downwardAPI": {
+                                              "properties": {
+                                                "items": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "fieldRef": {
+                                                        "properties": {
+                                                          "apiVersion": {
+                                                            "type": "string"
+                                                          },
+                                                          "fieldPath": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "mode": {
+                                                        "type": "integer"
+                                                      },
+                                                      "path": {
+                                                        "type": "string"
+                                                      },
+                                                      "resourceFieldRef": {
+                                                        "properties": {
+                                                          "containerName": {
+                                                            "type": "string"
+                                                          },
+                                                          "divisor": {
+                                                            "anyOf": [
+                                                              {
+                                                                "type": "integer"
+                                                              },
+                                                              {
+                                                                "type": "string"
+                                                              }
+                                                            ],
+                                                            "x-kubernetes-int-or-string": true
+                                                          },
+                                                          "resource": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "secret": {
+                                              "properties": {
+                                                "items": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "mode": {
+                                                        "type": "integer"
+                                                      },
+                                                      "path": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "serviceAccountToken": {
+                                              "properties": {
+                                                "audience": {
+                                                  "type": "string"
+                                                },
+                                                "expirationSeconds": {
+                                                  "type": "integer"
+                                                },
+                                                "path": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "quobyte": {
+                                    "properties": {
+                                      "group": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "registry": {
+                                        "type": "string"
+                                      },
+                                      "tenant": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      },
+                                      "volume": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "rbd": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "image": {
+                                        "type": "string"
+                                      },
+                                      "keyring": {
+                                        "type": "string"
+                                      },
+                                      "monitors": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "pool": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "scaleIO": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "gateway": {
+                                        "type": "string"
+                                      },
+                                      "protectionDomain": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sslEnabled": {
+                                        "type": "boolean"
+                                      },
+                                      "storageMode": {
+                                        "type": "string"
+                                      },
+                                      "storagePool": {
+                                        "type": "string"
+                                      },
+                                      "system": {
+                                        "type": "string"
+                                      },
+                                      "volumeName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "secret": {
+                                    "properties": {
+                                      "defaultMode": {
+                                        "type": "integer"
+                                      },
+                                      "items": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "mode": {
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      },
+                                      "secretName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "storageos": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "volumeName": {
+                                        "type": "string"
+                                      },
+                                      "volumeNamespace": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "vsphereVolume": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "storagePolicyID": {
+                                        "type": "string"
+                                      },
+                                      "storagePolicyName": {
+                                        "type": "string"
+                                      },
+                                      "volumePath": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "status": {
+                          "properties": {
+                            "conditions": {
+                              "items": {
+                                "properties": {
+                                  "lastProbeTime": {
+                                    "type": "string"
+                                  },
+                                  "lastTransitionTime": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "observedGeneration": {
+                                    "type": "integer"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "status": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "containerStatuses": {
+                              "items": {
+                                "properties": {
+                                  "allocatedResources": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "allocatedResourcesStatus": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "resources": {
+                                          "items": {
+                                            "properties": {
+                                              "health": {
+                                                "type": "string"
+                                              },
+                                              "resourceID": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imageID": {
+                                    "type": "string"
+                                  },
+                                  "lastState": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ready": {
+                                    "type": "boolean"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartCount": {
+                                    "type": "integer"
+                                  },
+                                  "started": {
+                                    "type": "boolean"
+                                  },
+                                  "state": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "properties": {
+                                      "linux": {
+                                        "properties": {
+                                          "gid": {
+                                            "type": "integer"
+                                          },
+                                          "supplementalGroups": {
+                                            "items": {
+                                              "type": "integer"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "uid": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "ephemeralContainerStatuses": {
+                              "items": {
+                                "properties": {
+                                  "allocatedResources": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "allocatedResourcesStatus": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "resources": {
+                                          "items": {
+                                            "properties": {
+                                              "health": {
+                                                "type": "string"
+                                              },
+                                              "resourceID": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imageID": {
+                                    "type": "string"
+                                  },
+                                  "lastState": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ready": {
+                                    "type": "boolean"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartCount": {
+                                    "type": "integer"
+                                  },
+                                  "started": {
+                                    "type": "boolean"
+                                  },
+                                  "state": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "properties": {
+                                      "linux": {
+                                        "properties": {
+                                          "gid": {
+                                            "type": "integer"
+                                          },
+                                          "supplementalGroups": {
+                                            "items": {
+                                              "type": "integer"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "uid": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostIPs": {
+                              "items": {
+                                "properties": {
+                                  "ip": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "initContainerStatuses": {
+                              "items": {
+                                "properties": {
+                                  "allocatedResources": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "allocatedResourcesStatus": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "resources": {
+                                          "items": {
+                                            "properties": {
+                                              "health": {
+                                                "type": "string"
+                                              },
+                                              "resourceID": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imageID": {
+                                    "type": "string"
+                                  },
+                                  "lastState": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ready": {
+                                    "type": "boolean"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartCount": {
+                                    "type": "integer"
+                                  },
+                                  "started": {
+                                    "type": "boolean"
+                                  },
+                                  "state": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "properties": {
+                                      "linux": {
+                                        "properties": {
+                                          "gid": {
+                                            "type": "integer"
+                                          },
+                                          "supplementalGroups": {
+                                            "items": {
+                                              "type": "integer"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "uid": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "message": {
+                              "type": "string"
+                            },
+                            "nominatedNodeName": {
+                              "type": "string"
+                            },
+                            "observedGeneration": {
+                              "type": "integer"
+                            },
+                            "phase": {
+                              "type": "string"
+                            },
+                            "podIP": {
+                              "type": "string"
+                            },
+                            "podIPs": {
+                              "items": {
+                                "properties": {
+                                  "ip": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "qosClass": {
+                              "type": "string"
+                            },
+                            "reason": {
+                              "type": "string"
+                            },
+                            "resize": {
+                              "type": "string"
+                            },
+                            "resourceClaimStatuses": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resourceClaimName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "startTime": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "replicas": {
+                      "type": "integer"
+                    },
+                    "resource": {
+                      "properties": {
+                        "cpu": {
+                          "type": "number"
+                        },
+                        "ephemeralStorage": {
+                          "type": "string"
+                        },
+                        "memory": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "abortTimestamp": {
+          "type": "string"
+        },
+        "blueGreenState": {
+          "enum": [
+            "ACTIVE_BLUE",
+            "ACTIVE_GREEN",
+            "INITIALIZING_BLUE",
+            "SAVEPOINTING_BLUE",
+            "SAVEPOINTING_GREEN",
+            "TRANSITIONING_TO_BLUE",
+            "TRANSITIONING_TO_GREEN"
+          ],
+          "type": "string"
+        },
+        "deploymentReadyTimestamp": {
+          "type": "string"
+        },
+        "error": {
+          "type": "string"
+        },
+        "jobStatus": {
+          "properties": {
+            "checkpointInfo": {
+              "properties": {
+                "formatType": {
+                  "enum": [
+                    "FULL",
+                    "INCREMENTAL",
+                    "UNKNOWN"
+                  ],
+                  "type": "string"
+                },
+                "lastCheckpoint": {
+                  "properties": {
+                    "formatType": {
+                      "enum": [
+                        "FULL",
+                        "INCREMENTAL",
+                        "UNKNOWN"
+                      ],
+                      "type": "string"
+                    },
+                    "timeStamp": {
+                      "type": "integer"
+                    },
+                    "triggerNonce": {
+                      "type": "integer"
+                    },
+                    "triggerType": {
+                      "enum": [
+                        "MANUAL",
+                        "PERIODIC",
+                        "UNKNOWN",
+                        "UPGRADE"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "lastPeriodicCheckpointTimestamp": {
+                  "type": "integer"
+                },
+                "triggerId": {
+                  "type": "string"
+                },
+                "triggerTimestamp": {
+                  "type": "integer"
+                },
+                "triggerType": {
+                  "enum": [
+                    "MANUAL",
+                    "PERIODIC",
+                    "UNKNOWN",
+                    "UPGRADE"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "jobId": {
+              "type": "string"
+            },
+            "jobName": {
+              "type": "string"
+            },
+            "savepointInfo": {
+              "properties": {
+                "formatType": {
+                  "enum": [
+                    "CANONICAL",
+                    "NATIVE",
+                    "UNKNOWN"
+                  ],
+                  "type": "string"
+                },
+                "lastPeriodicSavepointTimestamp": {
+                  "type": "integer"
+                },
+                "lastSavepoint": {
+                  "properties": {
+                    "formatType": {
+                      "enum": [
+                        "CANONICAL",
+                        "NATIVE",
+                        "UNKNOWN"
+                      ],
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    },
+                    "timeStamp": {
+                      "type": "integer"
+                    },
+                    "triggerNonce": {
+                      "type": "integer"
+                    },
+                    "triggerType": {
+                      "enum": [
+                        "MANUAL",
+                        "PERIODIC",
+                        "UNKNOWN",
+                        "UPGRADE"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "savepointHistory": {
+                  "items": {
+                    "properties": {
+                      "formatType": {
+                        "enum": [
+                          "CANONICAL",
+                          "NATIVE",
+                          "UNKNOWN"
+                        ],
+                        "type": "string"
+                      },
+                      "location": {
+                        "type": "string"
+                      },
+                      "timeStamp": {
+                        "type": "integer"
+                      },
+                      "triggerNonce": {
+                        "type": "integer"
+                      },
+                      "triggerType": {
+                        "enum": [
+                          "MANUAL",
+                          "PERIODIC",
+                          "UNKNOWN",
+                          "UPGRADE"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "triggerId": {
+                  "type": "string"
+                },
+                "triggerTimestamp": {
+                  "type": "integer"
+                },
+                "triggerType": {
+                  "enum": [
+                    "MANUAL",
+                    "PERIODIC",
+                    "UNKNOWN",
+                    "UPGRADE"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "startTime": {
+              "type": "string"
+            },
+            "state": {
+              "enum": [
+                "CANCELED",
+                "CANCELLING",
+                "CREATED",
+                "FAILED",
+                "FAILING",
+                "FINISHED",
+                "INITIALIZING",
+                "RECONCILING",
+                "RESTARTING",
+                "RUNNING",
+                "SUSPENDED"
+              ],
+              "type": "string"
+            },
+            "updateTime": {
+              "type": "string"
+            },
+            "upgradeSavepointPath": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "lastReconciledSpec": {
+          "type": "string"
+        },
+        "lastReconciledTimestamp": {
+          "type": "string"
+        },
+        "savepointTriggerId": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/master-standalone-strict/flinkdeployment_v1beta1.json
+++ b/master-standalone-strict/flinkdeployment_v1beta1.json
@@ -1,0 +1,18397 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "flinkConfiguration": {
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "flinkVersion": {
+          "enum": [
+            "v1_13",
+            "v1_14",
+            "v1_15",
+            "v1_16",
+            "v1_17",
+            "v1_18",
+            "v1_19",
+            "v1_20",
+            "v2_0",
+            "v2_1",
+            "v2_2"
+          ],
+          "type": "string"
+        },
+        "image": {
+          "type": "string"
+        },
+        "imagePullPolicy": {
+          "type": "string"
+        },
+        "ingress": {
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "className": {
+              "type": "string"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "template": {
+              "type": "string"
+            },
+            "tls": {
+              "items": {
+                "properties": {
+                  "hosts": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "secretName": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "job": {
+          "properties": {
+            "allowNonRestoredState": {
+              "type": "boolean"
+            },
+            "args": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "autoscalerResetNonce": {
+              "type": "integer"
+            },
+            "checkpointTriggerNonce": {
+              "type": "integer"
+            },
+            "entryClass": {
+              "type": "string"
+            },
+            "initialSavepointPath": {
+              "type": "string"
+            },
+            "jarURI": {
+              "type": "string"
+            },
+            "parallelism": {
+              "type": "integer"
+            },
+            "savepointRedeployNonce": {
+              "type": "integer"
+            },
+            "savepointTriggerNonce": {
+              "type": "integer"
+            },
+            "state": {
+              "enum": [
+                "running",
+                "suspended"
+              ],
+              "type": "string"
+            },
+            "upgradeMode": {
+              "enum": [
+                "last-state",
+                "savepoint",
+                "stateless"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "jobManager": {
+          "properties": {
+            "podTemplate": {
+              "properties": {
+                "apiVersion": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "metadata": {
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "creationTimestamp": {
+                      "type": "string"
+                    },
+                    "deletionGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "deletionTimestamp": {
+                      "type": "string"
+                    },
+                    "finalizers": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "generateName": {
+                      "type": "string"
+                    },
+                    "generation": {
+                      "type": "integer"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "managedFields": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "fieldsType": {
+                            "type": "string"
+                          },
+                          "fieldsV1": {
+                            "type": "object"
+                          },
+                          "manager": {
+                            "type": "string"
+                          },
+                          "operation": {
+                            "type": "string"
+                          },
+                          "subresource": {
+                            "type": "string"
+                          },
+                          "time": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    },
+                    "ownerReferences": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "blockOwnerDeletion": {
+                            "type": "boolean"
+                          },
+                          "controller": {
+                            "type": "boolean"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "uid": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "resourceVersion": {
+                      "type": "string"
+                    },
+                    "selfLink": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spec": {
+                  "properties": {
+                    "activeDeadlineSeconds": {
+                      "type": "integer"
+                    },
+                    "affinity": {
+                      "properties": {
+                        "nodeAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "preference": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "properties": {
+                                "nodeSelectorTerms": {
+                                  "items": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "podAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "podAntiAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "automountServiceAccountToken": {
+                      "type": "boolean"
+                    },
+                    "containers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "dnsConfig": {
+                      "properties": {
+                        "nameservers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "options": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "searches": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "dnsPolicy": {
+                      "type": "string"
+                    },
+                    "enableServiceLinks": {
+                      "type": "boolean"
+                    },
+                    "ephemeralContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "targetContainerName": {
+                            "type": "string"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "hostAliases": {
+                      "items": {
+                        "properties": {
+                          "hostnames": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "hostIPC": {
+                      "type": "boolean"
+                    },
+                    "hostNetwork": {
+                      "type": "boolean"
+                    },
+                    "hostPID": {
+                      "type": "boolean"
+                    },
+                    "hostUsers": {
+                      "type": "boolean"
+                    },
+                    "hostname": {
+                      "type": "string"
+                    },
+                    "imagePullSecrets": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "initContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "nodeName": {
+                      "type": "string"
+                    },
+                    "nodeSelector": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "os": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "overhead": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    },
+                    "preemptionPolicy": {
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "integer"
+                    },
+                    "priorityClassName": {
+                      "type": "string"
+                    },
+                    "readinessGates": {
+                      "items": {
+                        "properties": {
+                          "conditionType": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "resourceClaims": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "resourceClaimName": {
+                            "type": "string"
+                          },
+                          "resourceClaimTemplateName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "resources": {
+                      "properties": {
+                        "claims": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "request": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "limits": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "requests": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "restartPolicy": {
+                      "type": "string"
+                    },
+                    "runtimeClassName": {
+                      "type": "string"
+                    },
+                    "schedulerName": {
+                      "type": "string"
+                    },
+                    "schedulingGates": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "securityContext": {
+                      "properties": {
+                        "appArmorProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "fsGroup": {
+                          "type": "integer"
+                        },
+                        "fsGroupChangePolicy": {
+                          "type": "string"
+                        },
+                        "runAsGroup": {
+                          "type": "integer"
+                        },
+                        "runAsNonRoot": {
+                          "type": "boolean"
+                        },
+                        "runAsUser": {
+                          "type": "integer"
+                        },
+                        "seLinuxChangePolicy": {
+                          "type": "string"
+                        },
+                        "seLinuxOptions": {
+                          "properties": {
+                            "level": {
+                              "type": "string"
+                            },
+                            "role": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "seccompProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "supplementalGroups": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "supplementalGroupsPolicy": {
+                          "type": "string"
+                        },
+                        "sysctls": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "windowsOptions": {
+                          "properties": {
+                            "gmsaCredentialSpec": {
+                              "type": "string"
+                            },
+                            "gmsaCredentialSpecName": {
+                              "type": "string"
+                            },
+                            "hostProcess": {
+                              "type": "boolean"
+                            },
+                            "runAsUserName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "serviceAccount": {
+                      "type": "string"
+                    },
+                    "serviceAccountName": {
+                      "type": "string"
+                    },
+                    "setHostnameAsFQDN": {
+                      "type": "boolean"
+                    },
+                    "shareProcessNamespace": {
+                      "type": "boolean"
+                    },
+                    "subdomain": {
+                      "type": "string"
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "tolerations": {
+                      "items": {
+                        "properties": {
+                          "effect": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "tolerationSeconds": {
+                            "type": "integer"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "topologySpreadConstraints": {
+                      "items": {
+                        "properties": {
+                          "labelSelector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "matchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "maxSkew": {
+                            "type": "integer"
+                          },
+                          "minDomains": {
+                            "type": "integer"
+                          },
+                          "nodeAffinityPolicy": {
+                            "type": "string"
+                          },
+                          "nodeTaintsPolicy": {
+                            "type": "string"
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          },
+                          "whenUnsatisfiable": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "volumes": {
+                      "items": {
+                        "properties": {
+                          "awsElasticBlockStore": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azureDisk": {
+                            "properties": {
+                              "cachingMode": {
+                                "type": "string"
+                              },
+                              "diskName": {
+                                "type": "string"
+                              },
+                              "diskURI": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azureFile": {
+                            "properties": {
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              },
+                              "shareName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "cephfs": {
+                            "properties": {
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretFile": {
+                                "type": "string"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "cinder": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "configMap": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "csi": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "nodePublishSecretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeAttributes": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "downwardAPI": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "emptyDir": {
+                            "properties": {
+                              "medium": {
+                                "type": "string"
+                              },
+                              "sizeLimit": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "ephemeral": {
+                            "properties": {
+                              "volumeClaimTemplate": {
+                                "properties": {
+                                  "metadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "creationTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "deletionGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "deletionTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "finalizers": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "generateName": {
+                                        "type": "string"
+                                      },
+                                      "generation": {
+                                        "type": "integer"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "managedFields": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldsType": {
+                                              "type": "string"
+                                            },
+                                            "fieldsV1": {
+                                              "type": "object"
+                                            },
+                                            "manager": {
+                                              "type": "string"
+                                            },
+                                            "operation": {
+                                              "type": "string"
+                                            },
+                                            "subresource": {
+                                              "type": "string"
+                                            },
+                                            "time": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      },
+                                      "ownerReferences": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "blockOwnerDeletion": {
+                                              "type": "boolean"
+                                            },
+                                            "controller": {
+                                              "type": "boolean"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "uid": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "resourceVersion": {
+                                        "type": "string"
+                                      },
+                                      "selfLink": {
+                                        "type": "string"
+                                      },
+                                      "uid": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "spec": {
+                                    "properties": {
+                                      "accessModes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "dataSource": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "dataSourceRef": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "resources": {
+                                        "properties": {
+                                          "limits": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          },
+                                          "requests": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "selector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "storageClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeAttributesClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeMode": {
+                                        "type": "string"
+                                      },
+                                      "volumeName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "fc": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "targetWWNs": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "wwids": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "flexVolume": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "options": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "flocker": {
+                            "properties": {
+                              "datasetName": {
+                                "type": "string"
+                              },
+                              "datasetUUID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "gcePersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "pdName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "gitRepo": {
+                            "properties": {
+                              "directory": {
+                                "type": "string"
+                              },
+                              "repository": {
+                                "type": "string"
+                              },
+                              "revision": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "glusterfs": {
+                            "properties": {
+                              "endpoints": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "hostPath": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "image": {
+                            "properties": {
+                              "pullPolicy": {
+                                "type": "string"
+                              },
+                              "reference": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "iscsi": {
+                            "properties": {
+                              "chapAuthDiscovery": {
+                                "type": "boolean"
+                              },
+                              "chapAuthSession": {
+                                "type": "boolean"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "initiatorName": {
+                                "type": "string"
+                              },
+                              "iqn": {
+                                "type": "string"
+                              },
+                              "iscsiInterface": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "portals": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "targetPortal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "nfs": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "server": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "persistentVolumeClaim": {
+                            "properties": {
+                              "claimName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "photonPersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "pdID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "portworxVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "projected": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "sources": {
+                                "items": {
+                                  "properties": {
+                                    "clusterTrustBundle": {
+                                      "properties": {
+                                        "labelSelector": {
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "matchLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "signerName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "configMap": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "downwardAPI": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "fieldRef": {
+                                                "properties": {
+                                                  "apiVersion": {
+                                                    "type": "string"
+                                                  },
+                                                  "fieldPath": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "resourceFieldRef": {
+                                                "properties": {
+                                                  "containerName": {
+                                                    "type": "string"
+                                                  },
+                                                  "divisor": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "resource": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secret": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "serviceAccountToken": {
+                                      "properties": {
+                                        "audience": {
+                                          "type": "string"
+                                        },
+                                        "expirationSeconds": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "quobyte": {
+                            "properties": {
+                              "group": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "registry": {
+                                "type": "string"
+                              },
+                              "tenant": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              },
+                              "volume": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "rbd": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "keyring": {
+                                "type": "string"
+                              },
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "pool": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "scaleIO": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "gateway": {
+                                "type": "string"
+                              },
+                              "protectionDomain": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "sslEnabled": {
+                                "type": "boolean"
+                              },
+                              "storageMode": {
+                                "type": "string"
+                              },
+                              "storagePool": {
+                                "type": "string"
+                              },
+                              "system": {
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "secret": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "storageos": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              },
+                              "volumeNamespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "vsphereVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "storagePolicyID": {
+                                "type": "string"
+                              },
+                              "storagePolicyName": {
+                                "type": "string"
+                              },
+                              "volumePath": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "status": {
+                  "properties": {
+                    "conditions": {
+                      "items": {
+                        "properties": {
+                          "lastProbeTime": {
+                            "type": "string"
+                          },
+                          "lastTransitionTime": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "observedGeneration": {
+                            "type": "integer"
+                          },
+                          "reason": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "containerStatuses": {
+                      "items": {
+                        "properties": {
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "allocatedResourcesStatus": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "resources": {
+                                  "items": {
+                                    "properties": {
+                                      "health": {
+                                        "type": "string"
+                                      },
+                                      "resourceID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "containerID": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imageID": {
+                            "type": "string"
+                          },
+                          "lastState": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ready": {
+                            "type": "boolean"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartCount": {
+                            "type": "integer"
+                          },
+                          "started": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "properties": {
+                              "linux": {
+                                "properties": {
+                                  "gid": {
+                                    "type": "integer"
+                                  },
+                                  "supplementalGroups": {
+                                    "items": {
+                                      "type": "integer"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "uid": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "ephemeralContainerStatuses": {
+                      "items": {
+                        "properties": {
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "allocatedResourcesStatus": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "resources": {
+                                  "items": {
+                                    "properties": {
+                                      "health": {
+                                        "type": "string"
+                                      },
+                                      "resourceID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "containerID": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imageID": {
+                            "type": "string"
+                          },
+                          "lastState": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ready": {
+                            "type": "boolean"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartCount": {
+                            "type": "integer"
+                          },
+                          "started": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "properties": {
+                              "linux": {
+                                "properties": {
+                                  "gid": {
+                                    "type": "integer"
+                                  },
+                                  "supplementalGroups": {
+                                    "items": {
+                                      "type": "integer"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "uid": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "hostIP": {
+                      "type": "string"
+                    },
+                    "hostIPs": {
+                      "items": {
+                        "properties": {
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "initContainerStatuses": {
+                      "items": {
+                        "properties": {
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "allocatedResourcesStatus": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "resources": {
+                                  "items": {
+                                    "properties": {
+                                      "health": {
+                                        "type": "string"
+                                      },
+                                      "resourceID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "containerID": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imageID": {
+                            "type": "string"
+                          },
+                          "lastState": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ready": {
+                            "type": "boolean"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartCount": {
+                            "type": "integer"
+                          },
+                          "started": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "properties": {
+                              "linux": {
+                                "properties": {
+                                  "gid": {
+                                    "type": "integer"
+                                  },
+                                  "supplementalGroups": {
+                                    "items": {
+                                      "type": "integer"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "uid": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "nominatedNodeName": {
+                      "type": "string"
+                    },
+                    "observedGeneration": {
+                      "type": "integer"
+                    },
+                    "phase": {
+                      "type": "string"
+                    },
+                    "podIP": {
+                      "type": "string"
+                    },
+                    "podIPs": {
+                      "items": {
+                        "properties": {
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "qosClass": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    },
+                    "resize": {
+                      "type": "string"
+                    },
+                    "resourceClaimStatuses": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "resourceClaimName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "startTime": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "replicas": {
+              "type": "integer"
+            },
+            "resource": {
+              "properties": {
+                "cpu": {
+                  "type": "number"
+                },
+                "ephemeralStorage": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "logConfiguration": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "mode": {
+          "enum": [
+            "native",
+            "standalone"
+          ],
+          "type": "string"
+        },
+        "podTemplate": {
+          "properties": {
+            "apiVersion": {
+              "type": "string"
+            },
+            "kind": {
+              "type": "string"
+            },
+            "metadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "creationTimestamp": {
+                  "type": "string"
+                },
+                "deletionGracePeriodSeconds": {
+                  "type": "integer"
+                },
+                "deletionTimestamp": {
+                  "type": "string"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "generateName": {
+                  "type": "string"
+                },
+                "generation": {
+                  "type": "integer"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "managedFields": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "fieldsType": {
+                        "type": "string"
+                      },
+                      "fieldsV1": {
+                        "type": "object"
+                      },
+                      "manager": {
+                        "type": "string"
+                      },
+                      "operation": {
+                        "type": "string"
+                      },
+                      "subresource": {
+                        "type": "string"
+                      },
+                      "time": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "uid": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "resourceVersion": {
+                  "type": "string"
+                },
+                "selfLink": {
+                  "type": "string"
+                },
+                "uid": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "properties": {
+                "activeDeadlineSeconds": {
+                  "type": "integer"
+                },
+                "affinity": {
+                  "properties": {
+                    "nodeAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "preference": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchFields": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "properties": {
+                            "nodeSelectorTerms": {
+                              "items": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchFields": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "podAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "podAffinityTerm": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "namespaceSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "podAntiAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "podAffinityTerm": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "namespaceSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "automountServiceAccountToken": {
+                  "type": "boolean"
+                },
+                "containers": {
+                  "items": {
+                    "properties": {
+                      "args": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "env": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secretKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "envFrom": {
+                        "items": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "type": "string"
+                      },
+                      "lifecycle": {
+                        "properties": {
+                          "postStart": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "sleep": {
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "preStop": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "sleep": {
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "livenessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ports": {
+                        "items": {
+                          "properties": {
+                            "containerPort": {
+                              "type": "integer"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "readinessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resizePolicy": {
+                        "items": {
+                          "properties": {
+                            "resourceName": {
+                              "type": "string"
+                            },
+                            "restartPolicy": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "restartPolicy": {
+                        "type": "string"
+                      },
+                      "securityContext": {
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                          },
+                          "appArmorProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "capabilities": {
+                            "properties": {
+                              "add": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "drop": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "privileged": {
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "type": "string"
+                          },
+                          "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "type": "integer"
+                          },
+                          "runAsNonRoot": {
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "type": "integer"
+                          },
+                          "seLinuxOptions": {
+                            "properties": {
+                              "level": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "seccompProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "windowsOptions": {
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "startupProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stdin": {
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "type": "boolean"
+                      },
+                      "terminationMessagePath": {
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "type": "string"
+                      },
+                      "tty": {
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "items": {
+                          "properties": {
+                            "devicePath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            },
+                            "subPath": {
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "workingDir": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "dnsConfig": {
+                  "properties": {
+                    "nameservers": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "options": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "searches": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "dnsPolicy": {
+                  "type": "string"
+                },
+                "enableServiceLinks": {
+                  "type": "boolean"
+                },
+                "ephemeralContainers": {
+                  "items": {
+                    "properties": {
+                      "args": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "env": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secretKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "envFrom": {
+                        "items": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "type": "string"
+                      },
+                      "lifecycle": {
+                        "properties": {
+                          "postStart": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "sleep": {
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "preStop": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "sleep": {
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "livenessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ports": {
+                        "items": {
+                          "properties": {
+                            "containerPort": {
+                              "type": "integer"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "readinessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resizePolicy": {
+                        "items": {
+                          "properties": {
+                            "resourceName": {
+                              "type": "string"
+                            },
+                            "restartPolicy": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "restartPolicy": {
+                        "type": "string"
+                      },
+                      "securityContext": {
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                          },
+                          "appArmorProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "capabilities": {
+                            "properties": {
+                              "add": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "drop": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "privileged": {
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "type": "string"
+                          },
+                          "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "type": "integer"
+                          },
+                          "runAsNonRoot": {
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "type": "integer"
+                          },
+                          "seLinuxOptions": {
+                            "properties": {
+                              "level": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "seccompProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "windowsOptions": {
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "startupProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stdin": {
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "type": "boolean"
+                      },
+                      "targetContainerName": {
+                        "type": "string"
+                      },
+                      "terminationMessagePath": {
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "type": "string"
+                      },
+                      "tty": {
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "items": {
+                          "properties": {
+                            "devicePath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            },
+                            "subPath": {
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "workingDir": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "hostAliases": {
+                  "items": {
+                    "properties": {
+                      "hostnames": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "ip": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "hostIPC": {
+                  "type": "boolean"
+                },
+                "hostNetwork": {
+                  "type": "boolean"
+                },
+                "hostPID": {
+                  "type": "boolean"
+                },
+                "hostUsers": {
+                  "type": "boolean"
+                },
+                "hostname": {
+                  "type": "string"
+                },
+                "imagePullSecrets": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "initContainers": {
+                  "items": {
+                    "properties": {
+                      "args": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "env": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secretKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "envFrom": {
+                        "items": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "type": "string"
+                      },
+                      "lifecycle": {
+                        "properties": {
+                          "postStart": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "sleep": {
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "preStop": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "sleep": {
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "livenessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ports": {
+                        "items": {
+                          "properties": {
+                            "containerPort": {
+                              "type": "integer"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "readinessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resizePolicy": {
+                        "items": {
+                          "properties": {
+                            "resourceName": {
+                              "type": "string"
+                            },
+                            "restartPolicy": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "restartPolicy": {
+                        "type": "string"
+                      },
+                      "securityContext": {
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                          },
+                          "appArmorProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "capabilities": {
+                            "properties": {
+                              "add": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "drop": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "privileged": {
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "type": "string"
+                          },
+                          "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "type": "integer"
+                          },
+                          "runAsNonRoot": {
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "type": "integer"
+                          },
+                          "seLinuxOptions": {
+                            "properties": {
+                              "level": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "seccompProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "windowsOptions": {
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "startupProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stdin": {
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "type": "boolean"
+                      },
+                      "terminationMessagePath": {
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "type": "string"
+                      },
+                      "tty": {
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "items": {
+                          "properties": {
+                            "devicePath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            },
+                            "subPath": {
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "workingDir": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "nodeName": {
+                  "type": "string"
+                },
+                "nodeSelector": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "os": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "overhead": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
+                },
+                "preemptionPolicy": {
+                  "type": "string"
+                },
+                "priority": {
+                  "type": "integer"
+                },
+                "priorityClassName": {
+                  "type": "string"
+                },
+                "readinessGates": {
+                  "items": {
+                    "properties": {
+                      "conditionType": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "resourceClaims": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "resourceClaimName": {
+                        "type": "string"
+                      },
+                      "resourceClaimTemplateName": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "resources": {
+                  "properties": {
+                    "claims": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "request": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "limits": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    },
+                    "requests": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "restartPolicy": {
+                  "type": "string"
+                },
+                "runtimeClassName": {
+                  "type": "string"
+                },
+                "schedulerName": {
+                  "type": "string"
+                },
+                "schedulingGates": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "securityContext": {
+                  "properties": {
+                    "appArmorProfile": {
+                      "properties": {
+                        "localhostProfile": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "fsGroup": {
+                      "type": "integer"
+                    },
+                    "fsGroupChangePolicy": {
+                      "type": "string"
+                    },
+                    "runAsGroup": {
+                      "type": "integer"
+                    },
+                    "runAsNonRoot": {
+                      "type": "boolean"
+                    },
+                    "runAsUser": {
+                      "type": "integer"
+                    },
+                    "seLinuxChangePolicy": {
+                      "type": "string"
+                    },
+                    "seLinuxOptions": {
+                      "properties": {
+                        "level": {
+                          "type": "string"
+                        },
+                        "role": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "seccompProfile": {
+                      "properties": {
+                        "localhostProfile": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "supplementalGroups": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array"
+                    },
+                    "supplementalGroupsPolicy": {
+                      "type": "string"
+                    },
+                    "sysctls": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "windowsOptions": {
+                      "properties": {
+                        "gmsaCredentialSpec": {
+                          "type": "string"
+                        },
+                        "gmsaCredentialSpecName": {
+                          "type": "string"
+                        },
+                        "hostProcess": {
+                          "type": "boolean"
+                        },
+                        "runAsUserName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "serviceAccount": {
+                  "type": "string"
+                },
+                "serviceAccountName": {
+                  "type": "string"
+                },
+                "setHostnameAsFQDN": {
+                  "type": "boolean"
+                },
+                "shareProcessNamespace": {
+                  "type": "boolean"
+                },
+                "subdomain": {
+                  "type": "string"
+                },
+                "terminationGracePeriodSeconds": {
+                  "type": "integer"
+                },
+                "tolerations": {
+                  "items": {
+                    "properties": {
+                      "effect": {
+                        "type": "string"
+                      },
+                      "key": {
+                        "type": "string"
+                      },
+                      "operator": {
+                        "type": "string"
+                      },
+                      "tolerationSeconds": {
+                        "type": "integer"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "topologySpreadConstraints": {
+                  "items": {
+                    "properties": {
+                      "labelSelector": {
+                        "properties": {
+                          "matchExpressions": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "maxSkew": {
+                        "type": "integer"
+                      },
+                      "minDomains": {
+                        "type": "integer"
+                      },
+                      "nodeAffinityPolicy": {
+                        "type": "string"
+                      },
+                      "nodeTaintsPolicy": {
+                        "type": "string"
+                      },
+                      "topologyKey": {
+                        "type": "string"
+                      },
+                      "whenUnsatisfiable": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "volumes": {
+                  "items": {
+                    "properties": {
+                      "awsElasticBlockStore": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "partition": {
+                            "type": "integer"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "azureDisk": {
+                        "properties": {
+                          "cachingMode": {
+                            "type": "string"
+                          },
+                          "diskName": {
+                            "type": "string"
+                          },
+                          "diskURI": {
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "azureFile": {
+                        "properties": {
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          },
+                          "shareName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cephfs": {
+                        "properties": {
+                          "monitors": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretFile": {
+                            "type": "string"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "user": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cinder": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "volumeID": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "configMap": {
+                        "properties": {
+                          "defaultMode": {
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "csi": {
+                        "properties": {
+                          "driver": {
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "nodePublishSecretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "volumeAttributes": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "downwardAPI": {
+                        "properties": {
+                          "defaultMode": {
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "mode": {
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "emptyDir": {
+                        "properties": {
+                          "medium": {
+                            "type": "string"
+                          },
+                          "sizeLimit": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "ephemeral": {
+                        "properties": {
+                          "volumeClaimTemplate": {
+                            "properties": {
+                              "metadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "creationTimestamp": {
+                                    "type": "string"
+                                  },
+                                  "deletionGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "deletionTimestamp": {
+                                    "type": "string"
+                                  },
+                                  "finalizers": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "generateName": {
+                                    "type": "string"
+                                  },
+                                  "generation": {
+                                    "type": "integer"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "managedFields": {
+                                    "items": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldsType": {
+                                          "type": "string"
+                                        },
+                                        "fieldsV1": {
+                                          "type": "object"
+                                        },
+                                        "manager": {
+                                          "type": "string"
+                                        },
+                                        "operation": {
+                                          "type": "string"
+                                        },
+                                        "subresource": {
+                                          "type": "string"
+                                        },
+                                        "time": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "ownerReferences": {
+                                    "items": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "blockOwnerDeletion": {
+                                          "type": "boolean"
+                                        },
+                                        "controller": {
+                                          "type": "boolean"
+                                        },
+                                        "kind": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "uid": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "resourceVersion": {
+                                    "type": "string"
+                                  },
+                                  "selfLink": {
+                                    "type": "string"
+                                  },
+                                  "uid": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "spec": {
+                                "properties": {
+                                  "accessModes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "dataSource": {
+                                    "properties": {
+                                      "apiGroup": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "dataSourceRef": {
+                                    "properties": {
+                                      "apiGroup": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "selector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "storageClassName": {
+                                    "type": "string"
+                                  },
+                                  "volumeAttributesClassName": {
+                                    "type": "string"
+                                  },
+                                  "volumeMode": {
+                                    "type": "string"
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "fc": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "lun": {
+                            "type": "integer"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "targetWWNs": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "wwids": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "flexVolume": {
+                        "properties": {
+                          "driver": {
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "options": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "flocker": {
+                        "properties": {
+                          "datasetName": {
+                            "type": "string"
+                          },
+                          "datasetUUID": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "gcePersistentDisk": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "partition": {
+                            "type": "integer"
+                          },
+                          "pdName": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "gitRepo": {
+                        "properties": {
+                          "directory": {
+                            "type": "string"
+                          },
+                          "repository": {
+                            "type": "string"
+                          },
+                          "revision": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "glusterfs": {
+                        "properties": {
+                          "endpoints": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "hostPath": {
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "image": {
+                        "properties": {
+                          "pullPolicy": {
+                            "type": "string"
+                          },
+                          "reference": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "iscsi": {
+                        "properties": {
+                          "chapAuthDiscovery": {
+                            "type": "boolean"
+                          },
+                          "chapAuthSession": {
+                            "type": "boolean"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "initiatorName": {
+                            "type": "string"
+                          },
+                          "iqn": {
+                            "type": "string"
+                          },
+                          "iscsiInterface": {
+                            "type": "string"
+                          },
+                          "lun": {
+                            "type": "integer"
+                          },
+                          "portals": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "targetPortal": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "nfs": {
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "server": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "persistentVolumeClaim": {
+                        "properties": {
+                          "claimName": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "photonPersistentDisk": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "pdID": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "portworxVolume": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "projected": {
+                        "properties": {
+                          "defaultMode": {
+                            "type": "integer"
+                          },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "clusterTrustBundle": {
+                                  "properties": {
+                                    "labelSelector": {
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "matchLabels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "signerName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "configMap": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "downwardAPI": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "fieldRef": {
+                                            "properties": {
+                                              "apiVersion": {
+                                                "type": "string"
+                                              },
+                                              "fieldPath": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "mode": {
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "resourceFieldRef": {
+                                            "properties": {
+                                              "containerName": {
+                                                "type": "string"
+                                              },
+                                              "divisor": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "resource": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secret": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountToken": {
+                                  "properties": {
+                                    "audience": {
+                                      "type": "string"
+                                    },
+                                    "expirationSeconds": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "quobyte": {
+                        "properties": {
+                          "group": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "registry": {
+                            "type": "string"
+                          },
+                          "tenant": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "type": "string"
+                          },
+                          "volume": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "rbd": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "keyring": {
+                            "type": "string"
+                          },
+                          "monitors": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "pool": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "user": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "scaleIO": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "gateway": {
+                            "type": "string"
+                          },
+                          "protectionDomain": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "sslEnabled": {
+                            "type": "boolean"
+                          },
+                          "storageMode": {
+                            "type": "string"
+                          },
+                          "storagePool": {
+                            "type": "string"
+                          },
+                          "system": {
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "secret": {
+                        "properties": {
+                          "defaultMode": {
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "storageos": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "volumeName": {
+                            "type": "string"
+                          },
+                          "volumeNamespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "vsphereVolume": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "storagePolicyID": {
+                            "type": "string"
+                          },
+                          "storagePolicyName": {
+                            "type": "string"
+                          },
+                          "volumePath": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "status": {
+              "properties": {
+                "conditions": {
+                  "items": {
+                    "properties": {
+                      "lastProbeTime": {
+                        "type": "string"
+                      },
+                      "lastTransitionTime": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "type": "string"
+                      },
+                      "observedGeneration": {
+                        "type": "integer"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "containerStatuses": {
+                  "items": {
+                    "properties": {
+                      "allocatedResources": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
+                      "allocatedResourcesStatus": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "resources": {
+                              "items": {
+                                "properties": {
+                                  "health": {
+                                    "type": "string"
+                                  },
+                                  "resourceID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "containerID": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imageID": {
+                        "type": "string"
+                      },
+                      "lastState": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ready": {
+                        "type": "boolean"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "restartCount": {
+                        "type": "integer"
+                      },
+                      "started": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stopSignal": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "properties": {
+                          "linux": {
+                            "properties": {
+                              "gid": {
+                                "type": "integer"
+                              },
+                              "supplementalGroups": {
+                                "items": {
+                                  "type": "integer"
+                                },
+                                "type": "array"
+                              },
+                              "uid": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "ephemeralContainerStatuses": {
+                  "items": {
+                    "properties": {
+                      "allocatedResources": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
+                      "allocatedResourcesStatus": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "resources": {
+                              "items": {
+                                "properties": {
+                                  "health": {
+                                    "type": "string"
+                                  },
+                                  "resourceID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "containerID": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imageID": {
+                        "type": "string"
+                      },
+                      "lastState": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ready": {
+                        "type": "boolean"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "restartCount": {
+                        "type": "integer"
+                      },
+                      "started": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stopSignal": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "properties": {
+                          "linux": {
+                            "properties": {
+                              "gid": {
+                                "type": "integer"
+                              },
+                              "supplementalGroups": {
+                                "items": {
+                                  "type": "integer"
+                                },
+                                "type": "array"
+                              },
+                              "uid": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "hostIP": {
+                  "type": "string"
+                },
+                "hostIPs": {
+                  "items": {
+                    "properties": {
+                      "ip": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "initContainerStatuses": {
+                  "items": {
+                    "properties": {
+                      "allocatedResources": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
+                      "allocatedResourcesStatus": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "resources": {
+                              "items": {
+                                "properties": {
+                                  "health": {
+                                    "type": "string"
+                                  },
+                                  "resourceID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "containerID": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imageID": {
+                        "type": "string"
+                      },
+                      "lastState": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ready": {
+                        "type": "boolean"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "restartCount": {
+                        "type": "integer"
+                      },
+                      "started": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stopSignal": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "properties": {
+                          "linux": {
+                            "properties": {
+                              "gid": {
+                                "type": "integer"
+                              },
+                              "supplementalGroups": {
+                                "items": {
+                                  "type": "integer"
+                                },
+                                "type": "array"
+                              },
+                              "uid": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "nominatedNodeName": {
+                  "type": "string"
+                },
+                "observedGeneration": {
+                  "type": "integer"
+                },
+                "phase": {
+                  "type": "string"
+                },
+                "podIP": {
+                  "type": "string"
+                },
+                "podIPs": {
+                  "items": {
+                    "properties": {
+                      "ip": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "qosClass": {
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                },
+                "resize": {
+                  "type": "string"
+                },
+                "resourceClaimStatuses": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "resourceClaimName": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "startTime": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "restartNonce": {
+          "type": "integer"
+        },
+        "serviceAccount": {
+          "type": "string"
+        },
+        "taskManager": {
+          "properties": {
+            "podTemplate": {
+              "properties": {
+                "apiVersion": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "metadata": {
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "creationTimestamp": {
+                      "type": "string"
+                    },
+                    "deletionGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "deletionTimestamp": {
+                      "type": "string"
+                    },
+                    "finalizers": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "generateName": {
+                      "type": "string"
+                    },
+                    "generation": {
+                      "type": "integer"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "managedFields": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "fieldsType": {
+                            "type": "string"
+                          },
+                          "fieldsV1": {
+                            "type": "object"
+                          },
+                          "manager": {
+                            "type": "string"
+                          },
+                          "operation": {
+                            "type": "string"
+                          },
+                          "subresource": {
+                            "type": "string"
+                          },
+                          "time": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    },
+                    "ownerReferences": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "blockOwnerDeletion": {
+                            "type": "boolean"
+                          },
+                          "controller": {
+                            "type": "boolean"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "uid": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "resourceVersion": {
+                      "type": "string"
+                    },
+                    "selfLink": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spec": {
+                  "properties": {
+                    "activeDeadlineSeconds": {
+                      "type": "integer"
+                    },
+                    "affinity": {
+                      "properties": {
+                        "nodeAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "preference": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "properties": {
+                                "nodeSelectorTerms": {
+                                  "items": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "podAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "podAntiAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "automountServiceAccountToken": {
+                      "type": "boolean"
+                    },
+                    "containers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "dnsConfig": {
+                      "properties": {
+                        "nameservers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "options": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "searches": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "dnsPolicy": {
+                      "type": "string"
+                    },
+                    "enableServiceLinks": {
+                      "type": "boolean"
+                    },
+                    "ephemeralContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "targetContainerName": {
+                            "type": "string"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "hostAliases": {
+                      "items": {
+                        "properties": {
+                          "hostnames": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "hostIPC": {
+                      "type": "boolean"
+                    },
+                    "hostNetwork": {
+                      "type": "boolean"
+                    },
+                    "hostPID": {
+                      "type": "boolean"
+                    },
+                    "hostUsers": {
+                      "type": "boolean"
+                    },
+                    "hostname": {
+                      "type": "string"
+                    },
+                    "imagePullSecrets": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "initContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "nodeName": {
+                      "type": "string"
+                    },
+                    "nodeSelector": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "os": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "overhead": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    },
+                    "preemptionPolicy": {
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "integer"
+                    },
+                    "priorityClassName": {
+                      "type": "string"
+                    },
+                    "readinessGates": {
+                      "items": {
+                        "properties": {
+                          "conditionType": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "resourceClaims": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "resourceClaimName": {
+                            "type": "string"
+                          },
+                          "resourceClaimTemplateName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "resources": {
+                      "properties": {
+                        "claims": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "request": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "limits": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "requests": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "restartPolicy": {
+                      "type": "string"
+                    },
+                    "runtimeClassName": {
+                      "type": "string"
+                    },
+                    "schedulerName": {
+                      "type": "string"
+                    },
+                    "schedulingGates": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "securityContext": {
+                      "properties": {
+                        "appArmorProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "fsGroup": {
+                          "type": "integer"
+                        },
+                        "fsGroupChangePolicy": {
+                          "type": "string"
+                        },
+                        "runAsGroup": {
+                          "type": "integer"
+                        },
+                        "runAsNonRoot": {
+                          "type": "boolean"
+                        },
+                        "runAsUser": {
+                          "type": "integer"
+                        },
+                        "seLinuxChangePolicy": {
+                          "type": "string"
+                        },
+                        "seLinuxOptions": {
+                          "properties": {
+                            "level": {
+                              "type": "string"
+                            },
+                            "role": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "seccompProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "supplementalGroups": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "supplementalGroupsPolicy": {
+                          "type": "string"
+                        },
+                        "sysctls": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "windowsOptions": {
+                          "properties": {
+                            "gmsaCredentialSpec": {
+                              "type": "string"
+                            },
+                            "gmsaCredentialSpecName": {
+                              "type": "string"
+                            },
+                            "hostProcess": {
+                              "type": "boolean"
+                            },
+                            "runAsUserName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "serviceAccount": {
+                      "type": "string"
+                    },
+                    "serviceAccountName": {
+                      "type": "string"
+                    },
+                    "setHostnameAsFQDN": {
+                      "type": "boolean"
+                    },
+                    "shareProcessNamespace": {
+                      "type": "boolean"
+                    },
+                    "subdomain": {
+                      "type": "string"
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "tolerations": {
+                      "items": {
+                        "properties": {
+                          "effect": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "tolerationSeconds": {
+                            "type": "integer"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "topologySpreadConstraints": {
+                      "items": {
+                        "properties": {
+                          "labelSelector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "matchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "maxSkew": {
+                            "type": "integer"
+                          },
+                          "minDomains": {
+                            "type": "integer"
+                          },
+                          "nodeAffinityPolicy": {
+                            "type": "string"
+                          },
+                          "nodeTaintsPolicy": {
+                            "type": "string"
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          },
+                          "whenUnsatisfiable": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "volumes": {
+                      "items": {
+                        "properties": {
+                          "awsElasticBlockStore": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azureDisk": {
+                            "properties": {
+                              "cachingMode": {
+                                "type": "string"
+                              },
+                              "diskName": {
+                                "type": "string"
+                              },
+                              "diskURI": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azureFile": {
+                            "properties": {
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              },
+                              "shareName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "cephfs": {
+                            "properties": {
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretFile": {
+                                "type": "string"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "cinder": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "configMap": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "csi": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "nodePublishSecretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeAttributes": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "downwardAPI": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "emptyDir": {
+                            "properties": {
+                              "medium": {
+                                "type": "string"
+                              },
+                              "sizeLimit": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "ephemeral": {
+                            "properties": {
+                              "volumeClaimTemplate": {
+                                "properties": {
+                                  "metadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "creationTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "deletionGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "deletionTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "finalizers": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "generateName": {
+                                        "type": "string"
+                                      },
+                                      "generation": {
+                                        "type": "integer"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "managedFields": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldsType": {
+                                              "type": "string"
+                                            },
+                                            "fieldsV1": {
+                                              "type": "object"
+                                            },
+                                            "manager": {
+                                              "type": "string"
+                                            },
+                                            "operation": {
+                                              "type": "string"
+                                            },
+                                            "subresource": {
+                                              "type": "string"
+                                            },
+                                            "time": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      },
+                                      "ownerReferences": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "blockOwnerDeletion": {
+                                              "type": "boolean"
+                                            },
+                                            "controller": {
+                                              "type": "boolean"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "uid": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "resourceVersion": {
+                                        "type": "string"
+                                      },
+                                      "selfLink": {
+                                        "type": "string"
+                                      },
+                                      "uid": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "spec": {
+                                    "properties": {
+                                      "accessModes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "dataSource": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "dataSourceRef": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "resources": {
+                                        "properties": {
+                                          "limits": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          },
+                                          "requests": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "selector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "storageClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeAttributesClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeMode": {
+                                        "type": "string"
+                                      },
+                                      "volumeName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "fc": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "targetWWNs": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "wwids": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "flexVolume": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "options": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "flocker": {
+                            "properties": {
+                              "datasetName": {
+                                "type": "string"
+                              },
+                              "datasetUUID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "gcePersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "pdName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "gitRepo": {
+                            "properties": {
+                              "directory": {
+                                "type": "string"
+                              },
+                              "repository": {
+                                "type": "string"
+                              },
+                              "revision": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "glusterfs": {
+                            "properties": {
+                              "endpoints": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "hostPath": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "image": {
+                            "properties": {
+                              "pullPolicy": {
+                                "type": "string"
+                              },
+                              "reference": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "iscsi": {
+                            "properties": {
+                              "chapAuthDiscovery": {
+                                "type": "boolean"
+                              },
+                              "chapAuthSession": {
+                                "type": "boolean"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "initiatorName": {
+                                "type": "string"
+                              },
+                              "iqn": {
+                                "type": "string"
+                              },
+                              "iscsiInterface": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "portals": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "targetPortal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "nfs": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "server": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "persistentVolumeClaim": {
+                            "properties": {
+                              "claimName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "photonPersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "pdID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "portworxVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "projected": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "sources": {
+                                "items": {
+                                  "properties": {
+                                    "clusterTrustBundle": {
+                                      "properties": {
+                                        "labelSelector": {
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "matchLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "signerName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "configMap": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "downwardAPI": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "fieldRef": {
+                                                "properties": {
+                                                  "apiVersion": {
+                                                    "type": "string"
+                                                  },
+                                                  "fieldPath": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "resourceFieldRef": {
+                                                "properties": {
+                                                  "containerName": {
+                                                    "type": "string"
+                                                  },
+                                                  "divisor": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "resource": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secret": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "serviceAccountToken": {
+                                      "properties": {
+                                        "audience": {
+                                          "type": "string"
+                                        },
+                                        "expirationSeconds": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "quobyte": {
+                            "properties": {
+                              "group": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "registry": {
+                                "type": "string"
+                              },
+                              "tenant": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              },
+                              "volume": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "rbd": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "keyring": {
+                                "type": "string"
+                              },
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "pool": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "scaleIO": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "gateway": {
+                                "type": "string"
+                              },
+                              "protectionDomain": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "sslEnabled": {
+                                "type": "boolean"
+                              },
+                              "storageMode": {
+                                "type": "string"
+                              },
+                              "storagePool": {
+                                "type": "string"
+                              },
+                              "system": {
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "secret": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "storageos": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              },
+                              "volumeNamespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "vsphereVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "storagePolicyID": {
+                                "type": "string"
+                              },
+                              "storagePolicyName": {
+                                "type": "string"
+                              },
+                              "volumePath": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "status": {
+                  "properties": {
+                    "conditions": {
+                      "items": {
+                        "properties": {
+                          "lastProbeTime": {
+                            "type": "string"
+                          },
+                          "lastTransitionTime": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "observedGeneration": {
+                            "type": "integer"
+                          },
+                          "reason": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "containerStatuses": {
+                      "items": {
+                        "properties": {
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "allocatedResourcesStatus": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "resources": {
+                                  "items": {
+                                    "properties": {
+                                      "health": {
+                                        "type": "string"
+                                      },
+                                      "resourceID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "containerID": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imageID": {
+                            "type": "string"
+                          },
+                          "lastState": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ready": {
+                            "type": "boolean"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartCount": {
+                            "type": "integer"
+                          },
+                          "started": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "properties": {
+                              "linux": {
+                                "properties": {
+                                  "gid": {
+                                    "type": "integer"
+                                  },
+                                  "supplementalGroups": {
+                                    "items": {
+                                      "type": "integer"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "uid": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "ephemeralContainerStatuses": {
+                      "items": {
+                        "properties": {
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "allocatedResourcesStatus": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "resources": {
+                                  "items": {
+                                    "properties": {
+                                      "health": {
+                                        "type": "string"
+                                      },
+                                      "resourceID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "containerID": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imageID": {
+                            "type": "string"
+                          },
+                          "lastState": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ready": {
+                            "type": "boolean"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartCount": {
+                            "type": "integer"
+                          },
+                          "started": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "properties": {
+                              "linux": {
+                                "properties": {
+                                  "gid": {
+                                    "type": "integer"
+                                  },
+                                  "supplementalGroups": {
+                                    "items": {
+                                      "type": "integer"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "uid": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "hostIP": {
+                      "type": "string"
+                    },
+                    "hostIPs": {
+                      "items": {
+                        "properties": {
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "initContainerStatuses": {
+                      "items": {
+                        "properties": {
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "allocatedResourcesStatus": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "resources": {
+                                  "items": {
+                                    "properties": {
+                                      "health": {
+                                        "type": "string"
+                                      },
+                                      "resourceID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "containerID": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imageID": {
+                            "type": "string"
+                          },
+                          "lastState": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ready": {
+                            "type": "boolean"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartCount": {
+                            "type": "integer"
+                          },
+                          "started": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "properties": {
+                              "linux": {
+                                "properties": {
+                                  "gid": {
+                                    "type": "integer"
+                                  },
+                                  "supplementalGroups": {
+                                    "items": {
+                                      "type": "integer"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "uid": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "nominatedNodeName": {
+                      "type": "string"
+                    },
+                    "observedGeneration": {
+                      "type": "integer"
+                    },
+                    "phase": {
+                      "type": "string"
+                    },
+                    "podIP": {
+                      "type": "string"
+                    },
+                    "podIPs": {
+                      "items": {
+                        "properties": {
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "qosClass": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    },
+                    "resize": {
+                      "type": "string"
+                    },
+                    "resourceClaimStatuses": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "resourceClaimName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "startTime": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "replicas": {
+              "type": "integer"
+            },
+            "resource": {
+              "properties": {
+                "cpu": {
+                  "type": "number"
+                },
+                "ephemeralStorage": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "clusterInfo": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "conditions": {
+          "items": {
+            "properties": {
+              "lastTransitionTime": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "observedGeneration": {
+                "type": "integer"
+              },
+              "reason": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "error": {
+          "type": "string"
+        },
+        "jobManagerDeploymentStatus": {
+          "enum": [
+            "DEPLOYED_NOT_READY",
+            "DEPLOYING",
+            "ERROR",
+            "MISSING",
+            "READY"
+          ],
+          "type": "string"
+        },
+        "jobStatus": {
+          "properties": {
+            "checkpointInfo": {
+              "properties": {
+                "formatType": {
+                  "enum": [
+                    "FULL",
+                    "INCREMENTAL",
+                    "UNKNOWN"
+                  ],
+                  "type": "string"
+                },
+                "lastCheckpoint": {
+                  "properties": {
+                    "formatType": {
+                      "enum": [
+                        "FULL",
+                        "INCREMENTAL",
+                        "UNKNOWN"
+                      ],
+                      "type": "string"
+                    },
+                    "timeStamp": {
+                      "type": "integer"
+                    },
+                    "triggerNonce": {
+                      "type": "integer"
+                    },
+                    "triggerType": {
+                      "enum": [
+                        "MANUAL",
+                        "PERIODIC",
+                        "UNKNOWN",
+                        "UPGRADE"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "lastPeriodicCheckpointTimestamp": {
+                  "type": "integer"
+                },
+                "triggerId": {
+                  "type": "string"
+                },
+                "triggerTimestamp": {
+                  "type": "integer"
+                },
+                "triggerType": {
+                  "enum": [
+                    "MANUAL",
+                    "PERIODIC",
+                    "UNKNOWN",
+                    "UPGRADE"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "jobId": {
+              "type": "string"
+            },
+            "jobName": {
+              "type": "string"
+            },
+            "savepointInfo": {
+              "properties": {
+                "formatType": {
+                  "enum": [
+                    "CANONICAL",
+                    "NATIVE",
+                    "UNKNOWN"
+                  ],
+                  "type": "string"
+                },
+                "lastPeriodicSavepointTimestamp": {
+                  "type": "integer"
+                },
+                "lastSavepoint": {
+                  "properties": {
+                    "formatType": {
+                      "enum": [
+                        "CANONICAL",
+                        "NATIVE",
+                        "UNKNOWN"
+                      ],
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    },
+                    "timeStamp": {
+                      "type": "integer"
+                    },
+                    "triggerNonce": {
+                      "type": "integer"
+                    },
+                    "triggerType": {
+                      "enum": [
+                        "MANUAL",
+                        "PERIODIC",
+                        "UNKNOWN",
+                        "UPGRADE"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "savepointHistory": {
+                  "items": {
+                    "properties": {
+                      "formatType": {
+                        "enum": [
+                          "CANONICAL",
+                          "NATIVE",
+                          "UNKNOWN"
+                        ],
+                        "type": "string"
+                      },
+                      "location": {
+                        "type": "string"
+                      },
+                      "timeStamp": {
+                        "type": "integer"
+                      },
+                      "triggerNonce": {
+                        "type": "integer"
+                      },
+                      "triggerType": {
+                        "enum": [
+                          "MANUAL",
+                          "PERIODIC",
+                          "UNKNOWN",
+                          "UPGRADE"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "triggerId": {
+                  "type": "string"
+                },
+                "triggerTimestamp": {
+                  "type": "integer"
+                },
+                "triggerType": {
+                  "enum": [
+                    "MANUAL",
+                    "PERIODIC",
+                    "UNKNOWN",
+                    "UPGRADE"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "startTime": {
+              "type": "string"
+            },
+            "state": {
+              "enum": [
+                "CANCELED",
+                "CANCELLING",
+                "CREATED",
+                "FAILED",
+                "FAILING",
+                "FINISHED",
+                "INITIALIZING",
+                "RECONCILING",
+                "RESTARTING",
+                "RUNNING",
+                "SUSPENDED"
+              ],
+              "type": "string"
+            },
+            "updateTime": {
+              "type": "string"
+            },
+            "upgradeSavepointPath": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "lifecycleState": {
+          "enum": [
+            "CREATED",
+            "DELETED",
+            "DELETING",
+            "DEPLOYED",
+            "FAILED",
+            "ROLLED_BACK",
+            "ROLLING_BACK",
+            "STABLE",
+            "SUSPENDED",
+            "UPGRADING"
+          ],
+          "type": "string"
+        },
+        "observedGeneration": {
+          "type": "integer"
+        },
+        "reconciliationStatus": {
+          "properties": {
+            "lastReconciledSpec": {
+              "type": "string"
+            },
+            "lastStableSpec": {
+              "type": "string"
+            },
+            "reconciliationTimestamp": {
+              "type": "integer"
+            },
+            "state": {
+              "enum": [
+                "DEPLOYED",
+                "ROLLED_BACK",
+                "ROLLING_BACK",
+                "UPGRADING"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "taskManager": {
+          "properties": {
+            "labelSelector": {
+              "type": "string"
+            },
+            "replicas": {
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/master-standalone-strict/flinksessionjob_v1beta1.json
+++ b/master-standalone-strict/flinksessionjob_v1beta1.json
@@ -1,0 +1,322 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "deploymentName": {
+          "type": "string"
+        },
+        "flinkConfiguration": {
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "job": {
+          "properties": {
+            "allowNonRestoredState": {
+              "type": "boolean"
+            },
+            "args": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "autoscalerResetNonce": {
+              "type": "integer"
+            },
+            "checkpointTriggerNonce": {
+              "type": "integer"
+            },
+            "entryClass": {
+              "type": "string"
+            },
+            "initialSavepointPath": {
+              "type": "string"
+            },
+            "jarURI": {
+              "type": "string"
+            },
+            "parallelism": {
+              "type": "integer"
+            },
+            "savepointRedeployNonce": {
+              "type": "integer"
+            },
+            "savepointTriggerNonce": {
+              "type": "integer"
+            },
+            "state": {
+              "enum": [
+                "running",
+                "suspended"
+              ],
+              "type": "string"
+            },
+            "upgradeMode": {
+              "enum": [
+                "last-state",
+                "savepoint",
+                "stateless"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "restartNonce": {
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "jobStatus": {
+          "properties": {
+            "checkpointInfo": {
+              "properties": {
+                "formatType": {
+                  "enum": [
+                    "FULL",
+                    "INCREMENTAL",
+                    "UNKNOWN"
+                  ],
+                  "type": "string"
+                },
+                "lastCheckpoint": {
+                  "properties": {
+                    "formatType": {
+                      "enum": [
+                        "FULL",
+                        "INCREMENTAL",
+                        "UNKNOWN"
+                      ],
+                      "type": "string"
+                    },
+                    "timeStamp": {
+                      "type": "integer"
+                    },
+                    "triggerNonce": {
+                      "type": "integer"
+                    },
+                    "triggerType": {
+                      "enum": [
+                        "MANUAL",
+                        "PERIODIC",
+                        "UNKNOWN",
+                        "UPGRADE"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "lastPeriodicCheckpointTimestamp": {
+                  "type": "integer"
+                },
+                "triggerId": {
+                  "type": "string"
+                },
+                "triggerTimestamp": {
+                  "type": "integer"
+                },
+                "triggerType": {
+                  "enum": [
+                    "MANUAL",
+                    "PERIODIC",
+                    "UNKNOWN",
+                    "UPGRADE"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "jobId": {
+              "type": "string"
+            },
+            "jobName": {
+              "type": "string"
+            },
+            "savepointInfo": {
+              "properties": {
+                "formatType": {
+                  "enum": [
+                    "CANONICAL",
+                    "NATIVE",
+                    "UNKNOWN"
+                  ],
+                  "type": "string"
+                },
+                "lastPeriodicSavepointTimestamp": {
+                  "type": "integer"
+                },
+                "lastSavepoint": {
+                  "properties": {
+                    "formatType": {
+                      "enum": [
+                        "CANONICAL",
+                        "NATIVE",
+                        "UNKNOWN"
+                      ],
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    },
+                    "timeStamp": {
+                      "type": "integer"
+                    },
+                    "triggerNonce": {
+                      "type": "integer"
+                    },
+                    "triggerType": {
+                      "enum": [
+                        "MANUAL",
+                        "PERIODIC",
+                        "UNKNOWN",
+                        "UPGRADE"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "savepointHistory": {
+                  "items": {
+                    "properties": {
+                      "formatType": {
+                        "enum": [
+                          "CANONICAL",
+                          "NATIVE",
+                          "UNKNOWN"
+                        ],
+                        "type": "string"
+                      },
+                      "location": {
+                        "type": "string"
+                      },
+                      "timeStamp": {
+                        "type": "integer"
+                      },
+                      "triggerNonce": {
+                        "type": "integer"
+                      },
+                      "triggerType": {
+                        "enum": [
+                          "MANUAL",
+                          "PERIODIC",
+                          "UNKNOWN",
+                          "UPGRADE"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "triggerId": {
+                  "type": "string"
+                },
+                "triggerTimestamp": {
+                  "type": "integer"
+                },
+                "triggerType": {
+                  "enum": [
+                    "MANUAL",
+                    "PERIODIC",
+                    "UNKNOWN",
+                    "UPGRADE"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "startTime": {
+              "type": "string"
+            },
+            "state": {
+              "enum": [
+                "CANCELED",
+                "CANCELLING",
+                "CREATED",
+                "FAILED",
+                "FAILING",
+                "FINISHED",
+                "INITIALIZING",
+                "RECONCILING",
+                "RESTARTING",
+                "RUNNING",
+                "SUSPENDED"
+              ],
+              "type": "string"
+            },
+            "updateTime": {
+              "type": "string"
+            },
+            "upgradeSavepointPath": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "lifecycleState": {
+          "enum": [
+            "CREATED",
+            "DELETED",
+            "DELETING",
+            "DEPLOYED",
+            "FAILED",
+            "ROLLED_BACK",
+            "ROLLING_BACK",
+            "STABLE",
+            "SUSPENDED",
+            "UPGRADING"
+          ],
+          "type": "string"
+        },
+        "observedGeneration": {
+          "type": "integer"
+        },
+        "reconciliationStatus": {
+          "properties": {
+            "lastReconciledSpec": {
+              "type": "string"
+            },
+            "lastStableSpec": {
+              "type": "string"
+            },
+            "reconciliationTimestamp": {
+              "type": "integer"
+            },
+            "state": {
+              "enum": [
+                "DEPLOYED",
+                "ROLLED_BACK",
+                "ROLLING_BACK",
+                "UPGRADING"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/master-standalone-strict/flinkstatesnapshot_v1beta1.json
+++ b/master-standalone-strict/flinkstatesnapshot_v1beta1.json
@@ -1,0 +1,90 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "backoffLimit": {
+          "type": "integer"
+        },
+        "checkpoint": {
+          "type": "object"
+        },
+        "jobReference": {
+          "properties": {
+            "kind": {
+              "enum": [
+                "FlinkDeployment",
+                "FlinkSessionJob"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "savepoint": {
+          "properties": {
+            "alreadyExists": {
+              "type": "boolean"
+            },
+            "disposeOnDelete": {
+              "type": "boolean"
+            },
+            "formatType": {
+              "enum": [
+                "CANONICAL",
+                "NATIVE",
+                "UNKNOWN"
+              ],
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "failures": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string"
+        },
+        "resultTimestamp": {
+          "type": "string"
+        },
+        "state": {
+          "enum": [
+            "ABANDONED",
+            "COMPLETED",
+            "FAILED",
+            "IN_PROGRESS",
+            "TRIGGER_PENDING"
+          ],
+          "type": "string"
+        },
+        "triggerId": {
+          "type": "string"
+        },
+        "triggerTimestamp": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/master-standalone/flinkbluegreendeployment_v1beta1.json
+++ b/master-standalone/flinkbluegreendeployment_v1beta1.json
@@ -1,0 +1,18498 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "ingress": {
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "className": {
+              "type": "string"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "template": {
+              "type": "string"
+            },
+            "tls": {
+              "items": {
+                "properties": {
+                  "hosts": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "secretName": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "configuration": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "template": {
+          "properties": {
+            "metadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "creationTimestamp": {
+                  "type": "string"
+                },
+                "deletionGracePeriodSeconds": {
+                  "type": "integer"
+                },
+                "deletionTimestamp": {
+                  "type": "string"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "generateName": {
+                  "type": "string"
+                },
+                "generation": {
+                  "type": "integer"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "managedFields": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "fieldsType": {
+                        "type": "string"
+                      },
+                      "fieldsV1": {
+                        "type": "object"
+                      },
+                      "manager": {
+                        "type": "string"
+                      },
+                      "operation": {
+                        "type": "string"
+                      },
+                      "subresource": {
+                        "type": "string"
+                      },
+                      "time": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "uid": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "resourceVersion": {
+                  "type": "string"
+                },
+                "selfLink": {
+                  "type": "string"
+                },
+                "uid": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "properties": {
+                "flinkConfiguration": {
+                  "x-kubernetes-preserve-unknown-fields": true
+                },
+                "flinkVersion": {
+                  "enum": [
+                    "v1_13",
+                    "v1_14",
+                    "v1_15",
+                    "v1_16",
+                    "v1_17",
+                    "v1_18",
+                    "v1_19",
+                    "v1_20",
+                    "v2_0",
+                    "v2_1",
+                    "v2_2"
+                  ],
+                  "type": "string"
+                },
+                "image": {
+                  "type": "string"
+                },
+                "imagePullPolicy": {
+                  "type": "string"
+                },
+                "ingress": {
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "className": {
+                      "type": "string"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "template": {
+                      "type": "string"
+                    },
+                    "tls": {
+                      "items": {
+                        "properties": {
+                          "hosts": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "job": {
+                  "properties": {
+                    "allowNonRestoredState": {
+                      "type": "boolean"
+                    },
+                    "args": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "autoscalerResetNonce": {
+                      "type": "integer"
+                    },
+                    "checkpointTriggerNonce": {
+                      "type": "integer"
+                    },
+                    "entryClass": {
+                      "type": "string"
+                    },
+                    "initialSavepointPath": {
+                      "type": "string"
+                    },
+                    "jarURI": {
+                      "type": "string"
+                    },
+                    "parallelism": {
+                      "type": "integer"
+                    },
+                    "savepointRedeployNonce": {
+                      "type": "integer"
+                    },
+                    "savepointTriggerNonce": {
+                      "type": "integer"
+                    },
+                    "state": {
+                      "enum": [
+                        "running",
+                        "suspended"
+                      ],
+                      "type": "string"
+                    },
+                    "upgradeMode": {
+                      "enum": [
+                        "last-state",
+                        "savepoint",
+                        "stateless"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "jobManager": {
+                  "properties": {
+                    "podTemplate": {
+                      "properties": {
+                        "apiVersion": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string"
+                        },
+                        "metadata": {
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            },
+                            "creationTimestamp": {
+                              "type": "string"
+                            },
+                            "deletionGracePeriodSeconds": {
+                              "type": "integer"
+                            },
+                            "deletionTimestamp": {
+                              "type": "string"
+                            },
+                            "finalizers": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "generateName": {
+                              "type": "string"
+                            },
+                            "generation": {
+                              "type": "integer"
+                            },
+                            "labels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            },
+                            "managedFields": {
+                              "items": {
+                                "properties": {
+                                  "apiVersion": {
+                                    "type": "string"
+                                  },
+                                  "fieldsType": {
+                                    "type": "string"
+                                  },
+                                  "fieldsV1": {
+                                    "type": "object"
+                                  },
+                                  "manager": {
+                                    "type": "string"
+                                  },
+                                  "operation": {
+                                    "type": "string"
+                                  },
+                                  "subresource": {
+                                    "type": "string"
+                                  },
+                                  "time": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "type": "string"
+                            },
+                            "ownerReferences": {
+                              "items": {
+                                "properties": {
+                                  "apiVersion": {
+                                    "type": "string"
+                                  },
+                                  "blockOwnerDeletion": {
+                                    "type": "boolean"
+                                  },
+                                  "controller": {
+                                    "type": "boolean"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "uid": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "resourceVersion": {
+                              "type": "string"
+                            },
+                            "selfLink": {
+                              "type": "string"
+                            },
+                            "uid": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "spec": {
+                          "properties": {
+                            "activeDeadlineSeconds": {
+                              "type": "integer"
+                            },
+                            "affinity": {
+                              "properties": {
+                                "nodeAffinity": {
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "items": {
+                                        "properties": {
+                                          "preference": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchFields": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "properties": {
+                                        "nodeSelectorTerms": {
+                                          "items": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchFields": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "podAffinity": {
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "items": {
+                                        "properties": {
+                                          "podAffinityTerm": {
+                                            "properties": {
+                                              "labelSelector": {
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "matchLabelKeys": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "mismatchLabelKeys": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namespaceSelector": {
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaces": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "topologyKey": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "items": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "podAntiAffinity": {
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "items": {
+                                        "properties": {
+                                          "podAffinityTerm": {
+                                            "properties": {
+                                              "labelSelector": {
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "matchLabelKeys": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "mismatchLabelKeys": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namespaceSelector": {
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaces": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "topologyKey": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "items": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "automountServiceAccountToken": {
+                              "type": "boolean"
+                            },
+                            "containers": {
+                              "items": {
+                                "properties": {
+                                  "args": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "env": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "valueFrom": {
+                                          "properties": {
+                                            "configMapKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "fieldRef": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldPath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "resourceFieldRef": {
+                                              "properties": {
+                                                "containerName": {
+                                                  "type": "string"
+                                                },
+                                                "divisor": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "resource": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "secretKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "envFrom": {
+                                    "items": {
+                                      "properties": {
+                                        "configMapRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "prefix": {
+                                          "type": "string"
+                                        },
+                                        "secretRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imagePullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "lifecycle": {
+                                    "properties": {
+                                      "postStart": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "preStop": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "stopSignal": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "livenessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ports": {
+                                    "items": {
+                                      "properties": {
+                                        "containerPort": {
+                                          "type": "integer"
+                                        },
+                                        "hostIP": {
+                                          "type": "string"
+                                        },
+                                        "hostPort": {
+                                          "type": "integer"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "protocol": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "readinessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "resizePolicy": {
+                                    "items": {
+                                      "properties": {
+                                        "resourceName": {
+                                          "type": "string"
+                                        },
+                                        "restartPolicy": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartPolicy": {
+                                    "type": "string"
+                                  },
+                                  "securityContext": {
+                                    "properties": {
+                                      "allowPrivilegeEscalation": {
+                                        "type": "boolean"
+                                      },
+                                      "appArmorProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "capabilities": {
+                                        "properties": {
+                                          "add": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "drop": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "privileged": {
+                                        "type": "boolean"
+                                      },
+                                      "procMount": {
+                                        "type": "string"
+                                      },
+                                      "readOnlyRootFilesystem": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsGroup": {
+                                        "type": "integer"
+                                      },
+                                      "runAsNonRoot": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUser": {
+                                        "type": "integer"
+                                      },
+                                      "seLinuxOptions": {
+                                        "properties": {
+                                          "level": {
+                                            "type": "string"
+                                          },
+                                          "role": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          },
+                                          "user": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "seccompProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "windowsOptions": {
+                                        "properties": {
+                                          "gmsaCredentialSpec": {
+                                            "type": "string"
+                                          },
+                                          "gmsaCredentialSpecName": {
+                                            "type": "string"
+                                          },
+                                          "hostProcess": {
+                                            "type": "boolean"
+                                          },
+                                          "runAsUserName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "startupProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stdin": {
+                                    "type": "boolean"
+                                  },
+                                  "stdinOnce": {
+                                    "type": "boolean"
+                                  },
+                                  "terminationMessagePath": {
+                                    "type": "string"
+                                  },
+                                  "terminationMessagePolicy": {
+                                    "type": "string"
+                                  },
+                                  "tty": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeDevices": {
+                                    "items": {
+                                      "properties": {
+                                        "devicePath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "mountPropagation": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        },
+                                        "subPath": {
+                                          "type": "string"
+                                        },
+                                        "subPathExpr": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "workingDir": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "dnsConfig": {
+                              "properties": {
+                                "nameservers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "options": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "searches": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "dnsPolicy": {
+                              "type": "string"
+                            },
+                            "enableServiceLinks": {
+                              "type": "boolean"
+                            },
+                            "ephemeralContainers": {
+                              "items": {
+                                "properties": {
+                                  "args": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "env": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "valueFrom": {
+                                          "properties": {
+                                            "configMapKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "fieldRef": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldPath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "resourceFieldRef": {
+                                              "properties": {
+                                                "containerName": {
+                                                  "type": "string"
+                                                },
+                                                "divisor": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "resource": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "secretKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "envFrom": {
+                                    "items": {
+                                      "properties": {
+                                        "configMapRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "prefix": {
+                                          "type": "string"
+                                        },
+                                        "secretRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imagePullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "lifecycle": {
+                                    "properties": {
+                                      "postStart": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "preStop": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "stopSignal": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "livenessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ports": {
+                                    "items": {
+                                      "properties": {
+                                        "containerPort": {
+                                          "type": "integer"
+                                        },
+                                        "hostIP": {
+                                          "type": "string"
+                                        },
+                                        "hostPort": {
+                                          "type": "integer"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "protocol": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "readinessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "resizePolicy": {
+                                    "items": {
+                                      "properties": {
+                                        "resourceName": {
+                                          "type": "string"
+                                        },
+                                        "restartPolicy": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartPolicy": {
+                                    "type": "string"
+                                  },
+                                  "securityContext": {
+                                    "properties": {
+                                      "allowPrivilegeEscalation": {
+                                        "type": "boolean"
+                                      },
+                                      "appArmorProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "capabilities": {
+                                        "properties": {
+                                          "add": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "drop": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "privileged": {
+                                        "type": "boolean"
+                                      },
+                                      "procMount": {
+                                        "type": "string"
+                                      },
+                                      "readOnlyRootFilesystem": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsGroup": {
+                                        "type": "integer"
+                                      },
+                                      "runAsNonRoot": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUser": {
+                                        "type": "integer"
+                                      },
+                                      "seLinuxOptions": {
+                                        "properties": {
+                                          "level": {
+                                            "type": "string"
+                                          },
+                                          "role": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          },
+                                          "user": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "seccompProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "windowsOptions": {
+                                        "properties": {
+                                          "gmsaCredentialSpec": {
+                                            "type": "string"
+                                          },
+                                          "gmsaCredentialSpecName": {
+                                            "type": "string"
+                                          },
+                                          "hostProcess": {
+                                            "type": "boolean"
+                                          },
+                                          "runAsUserName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "startupProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stdin": {
+                                    "type": "boolean"
+                                  },
+                                  "stdinOnce": {
+                                    "type": "boolean"
+                                  },
+                                  "targetContainerName": {
+                                    "type": "string"
+                                  },
+                                  "terminationMessagePath": {
+                                    "type": "string"
+                                  },
+                                  "terminationMessagePolicy": {
+                                    "type": "string"
+                                  },
+                                  "tty": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeDevices": {
+                                    "items": {
+                                      "properties": {
+                                        "devicePath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "mountPropagation": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        },
+                                        "subPath": {
+                                          "type": "string"
+                                        },
+                                        "subPathExpr": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "workingDir": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "hostAliases": {
+                              "items": {
+                                "properties": {
+                                  "hostnames": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ip": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "hostIPC": {
+                              "type": "boolean"
+                            },
+                            "hostNetwork": {
+                              "type": "boolean"
+                            },
+                            "hostPID": {
+                              "type": "boolean"
+                            },
+                            "hostUsers": {
+                              "type": "boolean"
+                            },
+                            "hostname": {
+                              "type": "string"
+                            },
+                            "imagePullSecrets": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "initContainers": {
+                              "items": {
+                                "properties": {
+                                  "args": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "env": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "valueFrom": {
+                                          "properties": {
+                                            "configMapKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "fieldRef": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldPath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "resourceFieldRef": {
+                                              "properties": {
+                                                "containerName": {
+                                                  "type": "string"
+                                                },
+                                                "divisor": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "resource": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "secretKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "envFrom": {
+                                    "items": {
+                                      "properties": {
+                                        "configMapRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "prefix": {
+                                          "type": "string"
+                                        },
+                                        "secretRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imagePullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "lifecycle": {
+                                    "properties": {
+                                      "postStart": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "preStop": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "stopSignal": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "livenessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ports": {
+                                    "items": {
+                                      "properties": {
+                                        "containerPort": {
+                                          "type": "integer"
+                                        },
+                                        "hostIP": {
+                                          "type": "string"
+                                        },
+                                        "hostPort": {
+                                          "type": "integer"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "protocol": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "readinessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "resizePolicy": {
+                                    "items": {
+                                      "properties": {
+                                        "resourceName": {
+                                          "type": "string"
+                                        },
+                                        "restartPolicy": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartPolicy": {
+                                    "type": "string"
+                                  },
+                                  "securityContext": {
+                                    "properties": {
+                                      "allowPrivilegeEscalation": {
+                                        "type": "boolean"
+                                      },
+                                      "appArmorProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "capabilities": {
+                                        "properties": {
+                                          "add": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "drop": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "privileged": {
+                                        "type": "boolean"
+                                      },
+                                      "procMount": {
+                                        "type": "string"
+                                      },
+                                      "readOnlyRootFilesystem": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsGroup": {
+                                        "type": "integer"
+                                      },
+                                      "runAsNonRoot": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUser": {
+                                        "type": "integer"
+                                      },
+                                      "seLinuxOptions": {
+                                        "properties": {
+                                          "level": {
+                                            "type": "string"
+                                          },
+                                          "role": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          },
+                                          "user": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "seccompProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "windowsOptions": {
+                                        "properties": {
+                                          "gmsaCredentialSpec": {
+                                            "type": "string"
+                                          },
+                                          "gmsaCredentialSpecName": {
+                                            "type": "string"
+                                          },
+                                          "hostProcess": {
+                                            "type": "boolean"
+                                          },
+                                          "runAsUserName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "startupProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stdin": {
+                                    "type": "boolean"
+                                  },
+                                  "stdinOnce": {
+                                    "type": "boolean"
+                                  },
+                                  "terminationMessagePath": {
+                                    "type": "string"
+                                  },
+                                  "terminationMessagePolicy": {
+                                    "type": "string"
+                                  },
+                                  "tty": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeDevices": {
+                                    "items": {
+                                      "properties": {
+                                        "devicePath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "mountPropagation": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        },
+                                        "subPath": {
+                                          "type": "string"
+                                        },
+                                        "subPathExpr": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "workingDir": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "nodeName": {
+                              "type": "string"
+                            },
+                            "nodeSelector": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            },
+                            "os": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "overhead": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "preemptionPolicy": {
+                              "type": "string"
+                            },
+                            "priority": {
+                              "type": "integer"
+                            },
+                            "priorityClassName": {
+                              "type": "string"
+                            },
+                            "readinessGates": {
+                              "items": {
+                                "properties": {
+                                  "conditionType": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "resourceClaims": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resourceClaimName": {
+                                    "type": "string"
+                                  },
+                                  "resourceClaimTemplateName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "restartPolicy": {
+                              "type": "string"
+                            },
+                            "runtimeClassName": {
+                              "type": "string"
+                            },
+                            "schedulerName": {
+                              "type": "string"
+                            },
+                            "schedulingGates": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "securityContext": {
+                              "properties": {
+                                "appArmorProfile": {
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "fsGroup": {
+                                  "type": "integer"
+                                },
+                                "fsGroupChangePolicy": {
+                                  "type": "string"
+                                },
+                                "runAsGroup": {
+                                  "type": "integer"
+                                },
+                                "runAsNonRoot": {
+                                  "type": "boolean"
+                                },
+                                "runAsUser": {
+                                  "type": "integer"
+                                },
+                                "seLinuxChangePolicy": {
+                                  "type": "string"
+                                },
+                                "seLinuxOptions": {
+                                  "properties": {
+                                    "level": {
+                                      "type": "string"
+                                    },
+                                    "role": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    },
+                                    "user": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "seccompProfile": {
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "supplementalGroups": {
+                                  "items": {
+                                    "type": "integer"
+                                  },
+                                  "type": "array"
+                                },
+                                "supplementalGroupsPolicy": {
+                                  "type": "string"
+                                },
+                                "sysctls": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "windowsOptions": {
+                                  "properties": {
+                                    "gmsaCredentialSpec": {
+                                      "type": "string"
+                                    },
+                                    "gmsaCredentialSpecName": {
+                                      "type": "string"
+                                    },
+                                    "hostProcess": {
+                                      "type": "boolean"
+                                    },
+                                    "runAsUserName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccount": {
+                              "type": "string"
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "setHostnameAsFQDN": {
+                              "type": "boolean"
+                            },
+                            "shareProcessNamespace": {
+                              "type": "boolean"
+                            },
+                            "subdomain": {
+                              "type": "string"
+                            },
+                            "terminationGracePeriodSeconds": {
+                              "type": "integer"
+                            },
+                            "tolerations": {
+                              "items": {
+                                "properties": {
+                                  "effect": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "type": "string"
+                                  },
+                                  "tolerationSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "topologySpreadConstraints": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "maxSkew": {
+                                    "type": "integer"
+                                  },
+                                  "minDomains": {
+                                    "type": "integer"
+                                  },
+                                  "nodeAffinityPolicy": {
+                                    "type": "string"
+                                  },
+                                  "nodeTaintsPolicy": {
+                                    "type": "string"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  },
+                                  "whenUnsatisfiable": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "volumes": {
+                              "items": {
+                                "properties": {
+                                  "awsElasticBlockStore": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "partition": {
+                                        "type": "integer"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "volumeID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "azureDisk": {
+                                    "properties": {
+                                      "cachingMode": {
+                                        "type": "string"
+                                      },
+                                      "diskName": {
+                                        "type": "string"
+                                      },
+                                      "diskURI": {
+                                        "type": "string"
+                                      },
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "azureFile": {
+                                    "properties": {
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretName": {
+                                        "type": "string"
+                                      },
+                                      "shareName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "cephfs": {
+                                    "properties": {
+                                      "monitors": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretFile": {
+                                        "type": "string"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "cinder": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "volumeID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "configMap": {
+                                    "properties": {
+                                      "defaultMode": {
+                                        "type": "integer"
+                                      },
+                                      "items": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "mode": {
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "csi": {
+                                    "properties": {
+                                      "driver": {
+                                        "type": "string"
+                                      },
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "nodePublishSecretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "volumeAttributes": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "downwardAPI": {
+                                    "properties": {
+                                      "defaultMode": {
+                                        "type": "integer"
+                                      },
+                                      "items": {
+                                        "items": {
+                                          "properties": {
+                                            "fieldRef": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldPath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "mode": {
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "resourceFieldRef": {
+                                              "properties": {
+                                                "containerName": {
+                                                  "type": "string"
+                                                },
+                                                "divisor": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "resource": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "emptyDir": {
+                                    "properties": {
+                                      "medium": {
+                                        "type": "string"
+                                      },
+                                      "sizeLimit": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "ephemeral": {
+                                    "properties": {
+                                      "volumeClaimTemplate": {
+                                        "properties": {
+                                          "metadata": {
+                                            "properties": {
+                                              "annotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "creationTimestamp": {
+                                                "type": "string"
+                                              },
+                                              "deletionGracePeriodSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "deletionTimestamp": {
+                                                "type": "string"
+                                              },
+                                              "finalizers": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "generateName": {
+                                                "type": "string"
+                                              },
+                                              "generation": {
+                                                "type": "integer"
+                                              },
+                                              "labels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "managedFields": {
+                                                "items": {
+                                                  "properties": {
+                                                    "apiVersion": {
+                                                      "type": "string"
+                                                    },
+                                                    "fieldsType": {
+                                                      "type": "string"
+                                                    },
+                                                    "fieldsV1": {
+                                                      "type": "object"
+                                                    },
+                                                    "manager": {
+                                                      "type": "string"
+                                                    },
+                                                    "operation": {
+                                                      "type": "string"
+                                                    },
+                                                    "subresource": {
+                                                      "type": "string"
+                                                    },
+                                                    "time": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "ownerReferences": {
+                                                "items": {
+                                                  "properties": {
+                                                    "apiVersion": {
+                                                      "type": "string"
+                                                    },
+                                                    "blockOwnerDeletion": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "controller": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "kind": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "uid": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "resourceVersion": {
+                                                "type": "string"
+                                              },
+                                              "selfLink": {
+                                                "type": "string"
+                                              },
+                                              "uid": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "spec": {
+                                            "properties": {
+                                              "accessModes": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "dataSource": {
+                                                "properties": {
+                                                  "apiGroup": {
+                                                    "type": "string"
+                                                  },
+                                                  "kind": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "dataSourceRef": {
+                                                "properties": {
+                                                  "apiGroup": {
+                                                    "type": "string"
+                                                  },
+                                                  "kind": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "namespace": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "resources": {
+                                                "properties": {
+                                                  "limits": {
+                                                    "additionalProperties": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "requests": {
+                                                    "additionalProperties": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "selector": {
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "storageClassName": {
+                                                "type": "string"
+                                              },
+                                              "volumeAttributesClassName": {
+                                                "type": "string"
+                                              },
+                                              "volumeMode": {
+                                                "type": "string"
+                                              },
+                                              "volumeName": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "fc": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "lun": {
+                                        "type": "integer"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "targetWWNs": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "wwids": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "flexVolume": {
+                                    "properties": {
+                                      "driver": {
+                                        "type": "string"
+                                      },
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "options": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "flocker": {
+                                    "properties": {
+                                      "datasetName": {
+                                        "type": "string"
+                                      },
+                                      "datasetUUID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "gcePersistentDisk": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "partition": {
+                                        "type": "integer"
+                                      },
+                                      "pdName": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "gitRepo": {
+                                    "properties": {
+                                      "directory": {
+                                        "type": "string"
+                                      },
+                                      "repository": {
+                                        "type": "string"
+                                      },
+                                      "revision": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "glusterfs": {
+                                    "properties": {
+                                      "endpoints": {
+                                        "type": "string"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "hostPath": {
+                                    "properties": {
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "image": {
+                                    "properties": {
+                                      "pullPolicy": {
+                                        "type": "string"
+                                      },
+                                      "reference": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "iscsi": {
+                                    "properties": {
+                                      "chapAuthDiscovery": {
+                                        "type": "boolean"
+                                      },
+                                      "chapAuthSession": {
+                                        "type": "boolean"
+                                      },
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "initiatorName": {
+                                        "type": "string"
+                                      },
+                                      "iqn": {
+                                        "type": "string"
+                                      },
+                                      "iscsiInterface": {
+                                        "type": "string"
+                                      },
+                                      "lun": {
+                                        "type": "integer"
+                                      },
+                                      "portals": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "targetPortal": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "nfs": {
+                                    "properties": {
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "server": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "persistentVolumeClaim": {
+                                    "properties": {
+                                      "claimName": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "photonPersistentDisk": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "pdID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "portworxVolume": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "volumeID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "projected": {
+                                    "properties": {
+                                      "defaultMode": {
+                                        "type": "integer"
+                                      },
+                                      "sources": {
+                                        "items": {
+                                          "properties": {
+                                            "clusterTrustBundle": {
+                                              "properties": {
+                                                "labelSelector": {
+                                                  "properties": {
+                                                    "matchExpressions": {
+                                                      "items": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "operator": {
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "matchLabels": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                },
+                                                "path": {
+                                                  "type": "string"
+                                                },
+                                                "signerName": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "configMap": {
+                                              "properties": {
+                                                "items": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "mode": {
+                                                        "type": "integer"
+                                                      },
+                                                      "path": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "downwardAPI": {
+                                              "properties": {
+                                                "items": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "fieldRef": {
+                                                        "properties": {
+                                                          "apiVersion": {
+                                                            "type": "string"
+                                                          },
+                                                          "fieldPath": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "mode": {
+                                                        "type": "integer"
+                                                      },
+                                                      "path": {
+                                                        "type": "string"
+                                                      },
+                                                      "resourceFieldRef": {
+                                                        "properties": {
+                                                          "containerName": {
+                                                            "type": "string"
+                                                          },
+                                                          "divisor": {
+                                                            "anyOf": [
+                                                              {
+                                                                "type": "integer"
+                                                              },
+                                                              {
+                                                                "type": "string"
+                                                              }
+                                                            ],
+                                                            "x-kubernetes-int-or-string": true
+                                                          },
+                                                          "resource": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "secret": {
+                                              "properties": {
+                                                "items": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "mode": {
+                                                        "type": "integer"
+                                                      },
+                                                      "path": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "serviceAccountToken": {
+                                              "properties": {
+                                                "audience": {
+                                                  "type": "string"
+                                                },
+                                                "expirationSeconds": {
+                                                  "type": "integer"
+                                                },
+                                                "path": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "quobyte": {
+                                    "properties": {
+                                      "group": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "registry": {
+                                        "type": "string"
+                                      },
+                                      "tenant": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      },
+                                      "volume": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "rbd": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "image": {
+                                        "type": "string"
+                                      },
+                                      "keyring": {
+                                        "type": "string"
+                                      },
+                                      "monitors": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "pool": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "scaleIO": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "gateway": {
+                                        "type": "string"
+                                      },
+                                      "protectionDomain": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sslEnabled": {
+                                        "type": "boolean"
+                                      },
+                                      "storageMode": {
+                                        "type": "string"
+                                      },
+                                      "storagePool": {
+                                        "type": "string"
+                                      },
+                                      "system": {
+                                        "type": "string"
+                                      },
+                                      "volumeName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "secret": {
+                                    "properties": {
+                                      "defaultMode": {
+                                        "type": "integer"
+                                      },
+                                      "items": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "mode": {
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      },
+                                      "secretName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "storageos": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "volumeName": {
+                                        "type": "string"
+                                      },
+                                      "volumeNamespace": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "vsphereVolume": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "storagePolicyID": {
+                                        "type": "string"
+                                      },
+                                      "storagePolicyName": {
+                                        "type": "string"
+                                      },
+                                      "volumePath": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "status": {
+                          "properties": {
+                            "conditions": {
+                              "items": {
+                                "properties": {
+                                  "lastProbeTime": {
+                                    "type": "string"
+                                  },
+                                  "lastTransitionTime": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "observedGeneration": {
+                                    "type": "integer"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "status": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "containerStatuses": {
+                              "items": {
+                                "properties": {
+                                  "allocatedResources": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "allocatedResourcesStatus": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "resources": {
+                                          "items": {
+                                            "properties": {
+                                              "health": {
+                                                "type": "string"
+                                              },
+                                              "resourceID": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imageID": {
+                                    "type": "string"
+                                  },
+                                  "lastState": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ready": {
+                                    "type": "boolean"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartCount": {
+                                    "type": "integer"
+                                  },
+                                  "started": {
+                                    "type": "boolean"
+                                  },
+                                  "state": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "properties": {
+                                      "linux": {
+                                        "properties": {
+                                          "gid": {
+                                            "type": "integer"
+                                          },
+                                          "supplementalGroups": {
+                                            "items": {
+                                              "type": "integer"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "uid": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "ephemeralContainerStatuses": {
+                              "items": {
+                                "properties": {
+                                  "allocatedResources": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "allocatedResourcesStatus": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "resources": {
+                                          "items": {
+                                            "properties": {
+                                              "health": {
+                                                "type": "string"
+                                              },
+                                              "resourceID": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imageID": {
+                                    "type": "string"
+                                  },
+                                  "lastState": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ready": {
+                                    "type": "boolean"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartCount": {
+                                    "type": "integer"
+                                  },
+                                  "started": {
+                                    "type": "boolean"
+                                  },
+                                  "state": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "properties": {
+                                      "linux": {
+                                        "properties": {
+                                          "gid": {
+                                            "type": "integer"
+                                          },
+                                          "supplementalGroups": {
+                                            "items": {
+                                              "type": "integer"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "uid": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostIPs": {
+                              "items": {
+                                "properties": {
+                                  "ip": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "initContainerStatuses": {
+                              "items": {
+                                "properties": {
+                                  "allocatedResources": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "allocatedResourcesStatus": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "resources": {
+                                          "items": {
+                                            "properties": {
+                                              "health": {
+                                                "type": "string"
+                                              },
+                                              "resourceID": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imageID": {
+                                    "type": "string"
+                                  },
+                                  "lastState": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ready": {
+                                    "type": "boolean"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartCount": {
+                                    "type": "integer"
+                                  },
+                                  "started": {
+                                    "type": "boolean"
+                                  },
+                                  "state": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "properties": {
+                                      "linux": {
+                                        "properties": {
+                                          "gid": {
+                                            "type": "integer"
+                                          },
+                                          "supplementalGroups": {
+                                            "items": {
+                                              "type": "integer"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "uid": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "message": {
+                              "type": "string"
+                            },
+                            "nominatedNodeName": {
+                              "type": "string"
+                            },
+                            "observedGeneration": {
+                              "type": "integer"
+                            },
+                            "phase": {
+                              "type": "string"
+                            },
+                            "podIP": {
+                              "type": "string"
+                            },
+                            "podIPs": {
+                              "items": {
+                                "properties": {
+                                  "ip": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "qosClass": {
+                              "type": "string"
+                            },
+                            "reason": {
+                              "type": "string"
+                            },
+                            "resize": {
+                              "type": "string"
+                            },
+                            "resourceClaimStatuses": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resourceClaimName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "startTime": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "replicas": {
+                      "type": "integer"
+                    },
+                    "resource": {
+                      "properties": {
+                        "cpu": {
+                          "type": "number"
+                        },
+                        "ephemeralStorage": {
+                          "type": "string"
+                        },
+                        "memory": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "logConfiguration": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "mode": {
+                  "enum": [
+                    "native",
+                    "standalone"
+                  ],
+                  "type": "string"
+                },
+                "podTemplate": {
+                  "properties": {
+                    "apiVersion": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "metadata": {
+                      "properties": {
+                        "annotations": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "creationTimestamp": {
+                          "type": "string"
+                        },
+                        "deletionGracePeriodSeconds": {
+                          "type": "integer"
+                        },
+                        "deletionTimestamp": {
+                          "type": "string"
+                        },
+                        "finalizers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "generateName": {
+                          "type": "string"
+                        },
+                        "generation": {
+                          "type": "integer"
+                        },
+                        "labels": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "managedFields": {
+                          "items": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "fieldsType": {
+                                "type": "string"
+                              },
+                              "fieldsV1": {
+                                "type": "object"
+                              },
+                              "manager": {
+                                "type": "string"
+                              },
+                              "operation": {
+                                "type": "string"
+                              },
+                              "subresource": {
+                                "type": "string"
+                              },
+                              "time": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "type": "string"
+                        },
+                        "ownerReferences": {
+                          "items": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "blockOwnerDeletion": {
+                                "type": "boolean"
+                              },
+                              "controller": {
+                                "type": "boolean"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "uid": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "resourceVersion": {
+                          "type": "string"
+                        },
+                        "selfLink": {
+                          "type": "string"
+                        },
+                        "uid": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "spec": {
+                      "properties": {
+                        "activeDeadlineSeconds": {
+                          "type": "integer"
+                        },
+                        "affinity": {
+                          "properties": {
+                            "nodeAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "preference": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "properties": {
+                                    "nodeSelectorTerms": {
+                                      "items": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchFields": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "podAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "podAntiAffinity": {
+                              "properties": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "podAffinityTerm": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "weight": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                  "items": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "automountServiceAccountToken": {
+                          "type": "boolean"
+                        },
+                        "containers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "dnsConfig": {
+                          "properties": {
+                            "nameservers": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "options": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "searches": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "dnsPolicy": {
+                          "type": "string"
+                        },
+                        "enableServiceLinks": {
+                          "type": "boolean"
+                        },
+                        "ephemeralContainers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "targetContainerName": {
+                                "type": "string"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "hostAliases": {
+                          "items": {
+                            "properties": {
+                              "hostnames": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "ip": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "hostIPC": {
+                          "type": "boolean"
+                        },
+                        "hostNetwork": {
+                          "type": "boolean"
+                        },
+                        "hostPID": {
+                          "type": "boolean"
+                        },
+                        "hostUsers": {
+                          "type": "boolean"
+                        },
+                        "hostname": {
+                          "type": "string"
+                        },
+                        "imagePullSecrets": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "initContainers": {
+                          "items": {
+                            "properties": {
+                              "args": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "env": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "valueFrom": {
+                                      "properties": {
+                                        "configMapKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "secretKeyRef": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "envFrom": {
+                                "items": {
+                                  "properties": {
+                                    "configMapRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "prefix": {
+                                      "type": "string"
+                                    },
+                                    "secretRef": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imagePullPolicy": {
+                                "type": "string"
+                              },
+                              "lifecycle": {
+                                "properties": {
+                                  "postStart": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "preStop": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sleep": {
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "livenessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ports": {
+                                "items": {
+                                  "properties": {
+                                    "containerPort": {
+                                      "type": "integer"
+                                    },
+                                    "hostIP": {
+                                      "type": "string"
+                                    },
+                                    "hostPort": {
+                                      "type": "integer"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "protocol": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "readinessProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "resizePolicy": {
+                                "items": {
+                                  "properties": {
+                                    "resourceName": {
+                                      "type": "string"
+                                    },
+                                    "restartPolicy": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "restartPolicy": {
+                                "type": "string"
+                              },
+                              "securityContext": {
+                                "properties": {
+                                  "allowPrivilegeEscalation": {
+                                    "type": "boolean"
+                                  },
+                                  "appArmorProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "capabilities": {
+                                    "properties": {
+                                      "add": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "drop": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "privileged": {
+                                    "type": "boolean"
+                                  },
+                                  "procMount": {
+                                    "type": "string"
+                                  },
+                                  "readOnlyRootFilesystem": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsGroup": {
+                                    "type": "integer"
+                                  },
+                                  "runAsNonRoot": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUser": {
+                                    "type": "integer"
+                                  },
+                                  "seLinuxOptions": {
+                                    "properties": {
+                                      "level": {
+                                        "type": "string"
+                                      },
+                                      "role": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "seccompProfile": {
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "windowsOptions": {
+                                    "properties": {
+                                      "gmsaCredentialSpec": {
+                                        "type": "string"
+                                      },
+                                      "gmsaCredentialSpecName": {
+                                        "type": "string"
+                                      },
+                                      "hostProcess": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUserName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "startupProbe": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "failureThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "grpc": {
+                                    "properties": {
+                                      "port": {
+                                        "type": "integer"
+                                      },
+                                      "service": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "initialDelaySeconds": {
+                                    "type": "integer"
+                                  },
+                                  "periodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "successThreshold": {
+                                    "type": "integer"
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminationGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "timeoutSeconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stdin": {
+                                "type": "boolean"
+                              },
+                              "stdinOnce": {
+                                "type": "boolean"
+                              },
+                              "terminationMessagePath": {
+                                "type": "string"
+                              },
+                              "terminationMessagePolicy": {
+                                "type": "string"
+                              },
+                              "tty": {
+                                "type": "boolean"
+                              },
+                              "volumeDevices": {
+                                "items": {
+                                  "properties": {
+                                    "devicePath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "mountPropagation": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
+                                    "subPath": {
+                                      "type": "string"
+                                    },
+                                    "subPathExpr": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "workingDir": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "nodeName": {
+                          "type": "string"
+                        },
+                        "nodeSelector": {
+                          "additionalProperties": {
+                            "type": "string"
+                          },
+                          "type": "object"
+                        },
+                        "os": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "overhead": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "preemptionPolicy": {
+                          "type": "string"
+                        },
+                        "priority": {
+                          "type": "integer"
+                        },
+                        "priorityClassName": {
+                          "type": "string"
+                        },
+                        "readinessGates": {
+                          "items": {
+                            "properties": {
+                              "conditionType": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "resourceClaims": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "resourceClaimName": {
+                                "type": "string"
+                              },
+                              "resourceClaimTemplateName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "resources": {
+                          "properties": {
+                            "claims": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "limits": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "requests": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "restartPolicy": {
+                          "type": "string"
+                        },
+                        "runtimeClassName": {
+                          "type": "string"
+                        },
+                        "schedulerName": {
+                          "type": "string"
+                        },
+                        "schedulingGates": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "securityContext": {
+                          "properties": {
+                            "appArmorProfile": {
+                              "properties": {
+                                "localhostProfile": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "fsGroup": {
+                              "type": "integer"
+                            },
+                            "fsGroupChangePolicy": {
+                              "type": "string"
+                            },
+                            "runAsGroup": {
+                              "type": "integer"
+                            },
+                            "runAsNonRoot": {
+                              "type": "boolean"
+                            },
+                            "runAsUser": {
+                              "type": "integer"
+                            },
+                            "seLinuxChangePolicy": {
+                              "type": "string"
+                            },
+                            "seLinuxOptions": {
+                              "properties": {
+                                "level": {
+                                  "type": "string"
+                                },
+                                "role": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                },
+                                "user": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "seccompProfile": {
+                              "properties": {
+                                "localhostProfile": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "supplementalGroups": {
+                              "items": {
+                                "type": "integer"
+                              },
+                              "type": "array"
+                            },
+                            "supplementalGroupsPolicy": {
+                              "type": "string"
+                            },
+                            "sysctls": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "windowsOptions": {
+                              "properties": {
+                                "gmsaCredentialSpec": {
+                                  "type": "string"
+                                },
+                                "gmsaCredentialSpecName": {
+                                  "type": "string"
+                                },
+                                "hostProcess": {
+                                  "type": "boolean"
+                                },
+                                "runAsUserName": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "serviceAccount": {
+                          "type": "string"
+                        },
+                        "serviceAccountName": {
+                          "type": "string"
+                        },
+                        "setHostnameAsFQDN": {
+                          "type": "boolean"
+                        },
+                        "shareProcessNamespace": {
+                          "type": "boolean"
+                        },
+                        "subdomain": {
+                          "type": "string"
+                        },
+                        "terminationGracePeriodSeconds": {
+                          "type": "integer"
+                        },
+                        "tolerations": {
+                          "items": {
+                            "properties": {
+                              "effect": {
+                                "type": "string"
+                              },
+                              "key": {
+                                "type": "string"
+                              },
+                              "operator": {
+                                "type": "string"
+                              },
+                              "tolerationSeconds": {
+                                "type": "integer"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "topologySpreadConstraints": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "maxSkew": {
+                                "type": "integer"
+                              },
+                              "minDomains": {
+                                "type": "integer"
+                              },
+                              "nodeAffinityPolicy": {
+                                "type": "string"
+                              },
+                              "nodeTaintsPolicy": {
+                                "type": "string"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              },
+                              "whenUnsatisfiable": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "volumes": {
+                          "items": {
+                            "properties": {
+                              "awsElasticBlockStore": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "partition": {
+                                    "type": "integer"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "azureDisk": {
+                                "properties": {
+                                  "cachingMode": {
+                                    "type": "string"
+                                  },
+                                  "diskName": {
+                                    "type": "string"
+                                  },
+                                  "diskURI": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "azureFile": {
+                                "properties": {
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretName": {
+                                    "type": "string"
+                                  },
+                                  "shareName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "cephfs": {
+                                "properties": {
+                                  "monitors": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretFile": {
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "cinder": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "configMap": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "csi": {
+                                "properties": {
+                                  "driver": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "nodePublishSecretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeAttributes": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "downwardAPI": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "fieldRef": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldPath": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "resourceFieldRef": {
+                                          "properties": {
+                                            "containerName": {
+                                              "type": "string"
+                                            },
+                                            "divisor": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "resource": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "emptyDir": {
+                                "properties": {
+                                  "medium": {
+                                    "type": "string"
+                                  },
+                                  "sizeLimit": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "ephemeral": {
+                                "properties": {
+                                  "volumeClaimTemplate": {
+                                    "properties": {
+                                      "metadata": {
+                                        "properties": {
+                                          "annotations": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "creationTimestamp": {
+                                            "type": "string"
+                                          },
+                                          "deletionGracePeriodSeconds": {
+                                            "type": "integer"
+                                          },
+                                          "deletionTimestamp": {
+                                            "type": "string"
+                                          },
+                                          "finalizers": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "generateName": {
+                                            "type": "string"
+                                          },
+                                          "generation": {
+                                            "type": "integer"
+                                          },
+                                          "labels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          },
+                                          "managedFields": {
+                                            "items": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldsType": {
+                                                  "type": "string"
+                                                },
+                                                "fieldsV1": {
+                                                  "type": "object"
+                                                },
+                                                "manager": {
+                                                  "type": "string"
+                                                },
+                                                "operation": {
+                                                  "type": "string"
+                                                },
+                                                "subresource": {
+                                                  "type": "string"
+                                                },
+                                                "time": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          },
+                                          "ownerReferences": {
+                                            "items": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "blockOwnerDeletion": {
+                                                  "type": "boolean"
+                                                },
+                                                "controller": {
+                                                  "type": "boolean"
+                                                },
+                                                "kind": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "uid": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "resourceVersion": {
+                                            "type": "string"
+                                          },
+                                          "selfLink": {
+                                            "type": "string"
+                                          },
+                                          "uid": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "spec": {
+                                        "properties": {
+                                          "accessModes": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "dataSource": {
+                                            "properties": {
+                                              "apiGroup": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "dataSourceRef": {
+                                            "properties": {
+                                              "apiGroup": {
+                                                "type": "string"
+                                              },
+                                              "kind": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "resources": {
+                                            "properties": {
+                                              "limits": {
+                                                "additionalProperties": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "type": "object"
+                                              },
+                                              "requests": {
+                                                "additionalProperties": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "selector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "storageClassName": {
+                                            "type": "string"
+                                          },
+                                          "volumeAttributesClassName": {
+                                            "type": "string"
+                                          },
+                                          "volumeMode": {
+                                            "type": "string"
+                                          },
+                                          "volumeName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "fc": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "lun": {
+                                    "type": "integer"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "targetWWNs": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "wwids": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "flexVolume": {
+                                "properties": {
+                                  "driver": {
+                                    "type": "string"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "options": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "flocker": {
+                                "properties": {
+                                  "datasetName": {
+                                    "type": "string"
+                                  },
+                                  "datasetUUID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "gcePersistentDisk": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "partition": {
+                                    "type": "integer"
+                                  },
+                                  "pdName": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "gitRepo": {
+                                "properties": {
+                                  "directory": {
+                                    "type": "string"
+                                  },
+                                  "repository": {
+                                    "type": "string"
+                                  },
+                                  "revision": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "glusterfs": {
+                                "properties": {
+                                  "endpoints": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "hostPath": {
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "image": {
+                                "properties": {
+                                  "pullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "reference": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "iscsi": {
+                                "properties": {
+                                  "chapAuthDiscovery": {
+                                    "type": "boolean"
+                                  },
+                                  "chapAuthSession": {
+                                    "type": "boolean"
+                                  },
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "initiatorName": {
+                                    "type": "string"
+                                  },
+                                  "iqn": {
+                                    "type": "string"
+                                  },
+                                  "iscsiInterface": {
+                                    "type": "string"
+                                  },
+                                  "lun": {
+                                    "type": "integer"
+                                  },
+                                  "portals": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "targetPortal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "nfs": {
+                                "properties": {
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "server": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "persistentVolumeClaim": {
+                                "properties": {
+                                  "claimName": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "photonPersistentDisk": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "pdID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "portworxVolume": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "projected": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "sources": {
+                                    "items": {
+                                      "properties": {
+                                        "clusterTrustBundle": {
+                                          "properties": {
+                                            "labelSelector": {
+                                              "properties": {
+                                                "matchExpressions": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "matchLabels": {
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "object"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "signerName": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "configMap": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "downwardAPI": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "fieldRef": {
+                                                    "properties": {
+                                                      "apiVersion": {
+                                                        "type": "string"
+                                                      },
+                                                      "fieldPath": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "resourceFieldRef": {
+                                                    "properties": {
+                                                      "containerName": {
+                                                        "type": "string"
+                                                      },
+                                                      "divisor": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "integer"
+                                                          },
+                                                          {
+                                                            "type": "string"
+                                                          }
+                                                        ],
+                                                        "x-kubernetes-int-or-string": true
+                                                      },
+                                                      "resource": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "secret": {
+                                          "properties": {
+                                            "items": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "mode": {
+                                                    "type": "integer"
+                                                  },
+                                                  "path": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "serviceAccountToken": {
+                                          "properties": {
+                                            "audience": {
+                                              "type": "string"
+                                            },
+                                            "expirationSeconds": {
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "quobyte": {
+                                "properties": {
+                                  "group": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "registry": {
+                                    "type": "string"
+                                  },
+                                  "tenant": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  },
+                                  "volume": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "rbd": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "keyring": {
+                                    "type": "string"
+                                  },
+                                  "monitors": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "pool": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "scaleIO": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "gateway": {
+                                    "type": "string"
+                                  },
+                                  "protectionDomain": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sslEnabled": {
+                                    "type": "boolean"
+                                  },
+                                  "storageMode": {
+                                    "type": "string"
+                                  },
+                                  "storagePool": {
+                                    "type": "string"
+                                  },
+                                  "system": {
+                                    "type": "string"
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "secret": {
+                                "properties": {
+                                  "defaultMode": {
+                                    "type": "integer"
+                                  },
+                                  "items": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "mode": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "optional": {
+                                    "type": "boolean"
+                                  },
+                                  "secretName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "storageos": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  },
+                                  "secretRef": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  },
+                                  "volumeNamespace": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "vsphereVolume": {
+                                "properties": {
+                                  "fsType": {
+                                    "type": "string"
+                                  },
+                                  "storagePolicyID": {
+                                    "type": "string"
+                                  },
+                                  "storagePolicyName": {
+                                    "type": "string"
+                                  },
+                                  "volumePath": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "status": {
+                      "properties": {
+                        "conditions": {
+                          "items": {
+                            "properties": {
+                              "lastProbeTime": {
+                                "type": "string"
+                              },
+                              "lastTransitionTime": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "observedGeneration": {
+                                "type": "integer"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "containerStatuses": {
+                          "items": {
+                            "properties": {
+                              "allocatedResources": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "allocatedResourcesStatus": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "resources": {
+                                      "items": {
+                                        "properties": {
+                                          "health": {
+                                            "type": "string"
+                                          },
+                                          "resourceID": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imageID": {
+                                "type": "string"
+                              },
+                              "lastState": {
+                                "properties": {
+                                  "running": {
+                                    "properties": {
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminated": {
+                                    "properties": {
+                                      "containerID": {
+                                        "type": "string"
+                                      },
+                                      "exitCode": {
+                                        "type": "integer"
+                                      },
+                                      "finishedAt": {
+                                        "type": "string"
+                                      },
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      },
+                                      "signal": {
+                                        "type": "integer"
+                                      },
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "waiting": {
+                                    "properties": {
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ready": {
+                                "type": "boolean"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "restartCount": {
+                                "type": "integer"
+                              },
+                              "started": {
+                                "type": "boolean"
+                              },
+                              "state": {
+                                "properties": {
+                                  "running": {
+                                    "properties": {
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminated": {
+                                    "properties": {
+                                      "containerID": {
+                                        "type": "string"
+                                      },
+                                      "exitCode": {
+                                        "type": "integer"
+                                      },
+                                      "finishedAt": {
+                                        "type": "string"
+                                      },
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      },
+                                      "signal": {
+                                        "type": "integer"
+                                      },
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "waiting": {
+                                    "properties": {
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "properties": {
+                                  "linux": {
+                                    "properties": {
+                                      "gid": {
+                                        "type": "integer"
+                                      },
+                                      "supplementalGroups": {
+                                        "items": {
+                                          "type": "integer"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "uid": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "ephemeralContainerStatuses": {
+                          "items": {
+                            "properties": {
+                              "allocatedResources": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "allocatedResourcesStatus": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "resources": {
+                                      "items": {
+                                        "properties": {
+                                          "health": {
+                                            "type": "string"
+                                          },
+                                          "resourceID": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imageID": {
+                                "type": "string"
+                              },
+                              "lastState": {
+                                "properties": {
+                                  "running": {
+                                    "properties": {
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminated": {
+                                    "properties": {
+                                      "containerID": {
+                                        "type": "string"
+                                      },
+                                      "exitCode": {
+                                        "type": "integer"
+                                      },
+                                      "finishedAt": {
+                                        "type": "string"
+                                      },
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      },
+                                      "signal": {
+                                        "type": "integer"
+                                      },
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "waiting": {
+                                    "properties": {
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ready": {
+                                "type": "boolean"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "restartCount": {
+                                "type": "integer"
+                              },
+                              "started": {
+                                "type": "boolean"
+                              },
+                              "state": {
+                                "properties": {
+                                  "running": {
+                                    "properties": {
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminated": {
+                                    "properties": {
+                                      "containerID": {
+                                        "type": "string"
+                                      },
+                                      "exitCode": {
+                                        "type": "integer"
+                                      },
+                                      "finishedAt": {
+                                        "type": "string"
+                                      },
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      },
+                                      "signal": {
+                                        "type": "integer"
+                                      },
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "waiting": {
+                                    "properties": {
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "properties": {
+                                  "linux": {
+                                    "properties": {
+                                      "gid": {
+                                        "type": "integer"
+                                      },
+                                      "supplementalGroups": {
+                                        "items": {
+                                          "type": "integer"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "uid": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "hostIP": {
+                          "type": "string"
+                        },
+                        "hostIPs": {
+                          "items": {
+                            "properties": {
+                              "ip": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "initContainerStatuses": {
+                          "items": {
+                            "properties": {
+                              "allocatedResources": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "allocatedResourcesStatus": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "resources": {
+                                      "items": {
+                                        "properties": {
+                                          "health": {
+                                            "type": "string"
+                                          },
+                                          "resourceID": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "imageID": {
+                                "type": "string"
+                              },
+                              "lastState": {
+                                "properties": {
+                                  "running": {
+                                    "properties": {
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminated": {
+                                    "properties": {
+                                      "containerID": {
+                                        "type": "string"
+                                      },
+                                      "exitCode": {
+                                        "type": "integer"
+                                      },
+                                      "finishedAt": {
+                                        "type": "string"
+                                      },
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      },
+                                      "signal": {
+                                        "type": "integer"
+                                      },
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "waiting": {
+                                    "properties": {
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "ready": {
+                                "type": "boolean"
+                              },
+                              "resources": {
+                                "properties": {
+                                  "claims": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "limits": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "requests": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "restartCount": {
+                                "type": "integer"
+                              },
+                              "started": {
+                                "type": "boolean"
+                              },
+                              "state": {
+                                "properties": {
+                                  "running": {
+                                    "properties": {
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "terminated": {
+                                    "properties": {
+                                      "containerID": {
+                                        "type": "string"
+                                      },
+                                      "exitCode": {
+                                        "type": "integer"
+                                      },
+                                      "finishedAt": {
+                                        "type": "string"
+                                      },
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      },
+                                      "signal": {
+                                        "type": "integer"
+                                      },
+                                      "startedAt": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "waiting": {
+                                    "properties": {
+                                      "message": {
+                                        "type": "string"
+                                      },
+                                      "reason": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "properties": {
+                                  "linux": {
+                                    "properties": {
+                                      "gid": {
+                                        "type": "integer"
+                                      },
+                                      "supplementalGroups": {
+                                        "items": {
+                                          "type": "integer"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "uid": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "volumeMounts": {
+                                "items": {
+                                  "properties": {
+                                    "mountPath": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "readOnly": {
+                                      "type": "boolean"
+                                    },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "nominatedNodeName": {
+                          "type": "string"
+                        },
+                        "observedGeneration": {
+                          "type": "integer"
+                        },
+                        "phase": {
+                          "type": "string"
+                        },
+                        "podIP": {
+                          "type": "string"
+                        },
+                        "podIPs": {
+                          "items": {
+                            "properties": {
+                              "ip": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "qosClass": {
+                          "type": "string"
+                        },
+                        "reason": {
+                          "type": "string"
+                        },
+                        "resize": {
+                          "type": "string"
+                        },
+                        "resourceClaimStatuses": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "resourceClaimName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "startTime": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "restartNonce": {
+                  "type": "integer"
+                },
+                "serviceAccount": {
+                  "type": "string"
+                },
+                "taskManager": {
+                  "properties": {
+                    "podTemplate": {
+                      "properties": {
+                        "apiVersion": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string"
+                        },
+                        "metadata": {
+                          "properties": {
+                            "annotations": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            },
+                            "creationTimestamp": {
+                              "type": "string"
+                            },
+                            "deletionGracePeriodSeconds": {
+                              "type": "integer"
+                            },
+                            "deletionTimestamp": {
+                              "type": "string"
+                            },
+                            "finalizers": {
+                              "items": {
+                                "type": "string"
+                              },
+                              "type": "array"
+                            },
+                            "generateName": {
+                              "type": "string"
+                            },
+                            "generation": {
+                              "type": "integer"
+                            },
+                            "labels": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            },
+                            "managedFields": {
+                              "items": {
+                                "properties": {
+                                  "apiVersion": {
+                                    "type": "string"
+                                  },
+                                  "fieldsType": {
+                                    "type": "string"
+                                  },
+                                  "fieldsV1": {
+                                    "type": "object"
+                                  },
+                                  "manager": {
+                                    "type": "string"
+                                  },
+                                  "operation": {
+                                    "type": "string"
+                                  },
+                                  "subresource": {
+                                    "type": "string"
+                                  },
+                                  "time": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "type": "string"
+                            },
+                            "ownerReferences": {
+                              "items": {
+                                "properties": {
+                                  "apiVersion": {
+                                    "type": "string"
+                                  },
+                                  "blockOwnerDeletion": {
+                                    "type": "boolean"
+                                  },
+                                  "controller": {
+                                    "type": "boolean"
+                                  },
+                                  "kind": {
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "uid": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "resourceVersion": {
+                              "type": "string"
+                            },
+                            "selfLink": {
+                              "type": "string"
+                            },
+                            "uid": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "spec": {
+                          "properties": {
+                            "activeDeadlineSeconds": {
+                              "type": "integer"
+                            },
+                            "affinity": {
+                              "properties": {
+                                "nodeAffinity": {
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "items": {
+                                        "properties": {
+                                          "preference": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchFields": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "properties": {
+                                        "nodeSelectorTerms": {
+                                          "items": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchFields": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "podAffinity": {
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "items": {
+                                        "properties": {
+                                          "podAffinityTerm": {
+                                            "properties": {
+                                              "labelSelector": {
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "matchLabelKeys": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "mismatchLabelKeys": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namespaceSelector": {
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaces": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "topologyKey": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "items": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "podAntiAffinity": {
+                                  "properties": {
+                                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                                      "items": {
+                                        "properties": {
+                                          "podAffinityTerm": {
+                                            "properties": {
+                                              "labelSelector": {
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "matchLabelKeys": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "mismatchLabelKeys": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "namespaceSelector": {
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "namespaces": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "topologyKey": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "weight": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                                      "items": {
+                                        "properties": {
+                                          "labelSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "matchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "namespaceSelector": {
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "matchLabels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "namespaces": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "topologyKey": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "automountServiceAccountToken": {
+                              "type": "boolean"
+                            },
+                            "containers": {
+                              "items": {
+                                "properties": {
+                                  "args": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "env": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "valueFrom": {
+                                          "properties": {
+                                            "configMapKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "fieldRef": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldPath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "resourceFieldRef": {
+                                              "properties": {
+                                                "containerName": {
+                                                  "type": "string"
+                                                },
+                                                "divisor": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "resource": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "secretKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "envFrom": {
+                                    "items": {
+                                      "properties": {
+                                        "configMapRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "prefix": {
+                                          "type": "string"
+                                        },
+                                        "secretRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imagePullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "lifecycle": {
+                                    "properties": {
+                                      "postStart": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "preStop": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "stopSignal": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "livenessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ports": {
+                                    "items": {
+                                      "properties": {
+                                        "containerPort": {
+                                          "type": "integer"
+                                        },
+                                        "hostIP": {
+                                          "type": "string"
+                                        },
+                                        "hostPort": {
+                                          "type": "integer"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "protocol": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "readinessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "resizePolicy": {
+                                    "items": {
+                                      "properties": {
+                                        "resourceName": {
+                                          "type": "string"
+                                        },
+                                        "restartPolicy": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartPolicy": {
+                                    "type": "string"
+                                  },
+                                  "securityContext": {
+                                    "properties": {
+                                      "allowPrivilegeEscalation": {
+                                        "type": "boolean"
+                                      },
+                                      "appArmorProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "capabilities": {
+                                        "properties": {
+                                          "add": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "drop": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "privileged": {
+                                        "type": "boolean"
+                                      },
+                                      "procMount": {
+                                        "type": "string"
+                                      },
+                                      "readOnlyRootFilesystem": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsGroup": {
+                                        "type": "integer"
+                                      },
+                                      "runAsNonRoot": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUser": {
+                                        "type": "integer"
+                                      },
+                                      "seLinuxOptions": {
+                                        "properties": {
+                                          "level": {
+                                            "type": "string"
+                                          },
+                                          "role": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          },
+                                          "user": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "seccompProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "windowsOptions": {
+                                        "properties": {
+                                          "gmsaCredentialSpec": {
+                                            "type": "string"
+                                          },
+                                          "gmsaCredentialSpecName": {
+                                            "type": "string"
+                                          },
+                                          "hostProcess": {
+                                            "type": "boolean"
+                                          },
+                                          "runAsUserName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "startupProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stdin": {
+                                    "type": "boolean"
+                                  },
+                                  "stdinOnce": {
+                                    "type": "boolean"
+                                  },
+                                  "terminationMessagePath": {
+                                    "type": "string"
+                                  },
+                                  "terminationMessagePolicy": {
+                                    "type": "string"
+                                  },
+                                  "tty": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeDevices": {
+                                    "items": {
+                                      "properties": {
+                                        "devicePath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "mountPropagation": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        },
+                                        "subPath": {
+                                          "type": "string"
+                                        },
+                                        "subPathExpr": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "workingDir": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "dnsConfig": {
+                              "properties": {
+                                "nameservers": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "options": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "searches": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "dnsPolicy": {
+                              "type": "string"
+                            },
+                            "enableServiceLinks": {
+                              "type": "boolean"
+                            },
+                            "ephemeralContainers": {
+                              "items": {
+                                "properties": {
+                                  "args": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "env": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "valueFrom": {
+                                          "properties": {
+                                            "configMapKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "fieldRef": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldPath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "resourceFieldRef": {
+                                              "properties": {
+                                                "containerName": {
+                                                  "type": "string"
+                                                },
+                                                "divisor": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "resource": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "secretKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "envFrom": {
+                                    "items": {
+                                      "properties": {
+                                        "configMapRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "prefix": {
+                                          "type": "string"
+                                        },
+                                        "secretRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imagePullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "lifecycle": {
+                                    "properties": {
+                                      "postStart": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "preStop": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "stopSignal": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "livenessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ports": {
+                                    "items": {
+                                      "properties": {
+                                        "containerPort": {
+                                          "type": "integer"
+                                        },
+                                        "hostIP": {
+                                          "type": "string"
+                                        },
+                                        "hostPort": {
+                                          "type": "integer"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "protocol": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "readinessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "resizePolicy": {
+                                    "items": {
+                                      "properties": {
+                                        "resourceName": {
+                                          "type": "string"
+                                        },
+                                        "restartPolicy": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartPolicy": {
+                                    "type": "string"
+                                  },
+                                  "securityContext": {
+                                    "properties": {
+                                      "allowPrivilegeEscalation": {
+                                        "type": "boolean"
+                                      },
+                                      "appArmorProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "capabilities": {
+                                        "properties": {
+                                          "add": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "drop": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "privileged": {
+                                        "type": "boolean"
+                                      },
+                                      "procMount": {
+                                        "type": "string"
+                                      },
+                                      "readOnlyRootFilesystem": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsGroup": {
+                                        "type": "integer"
+                                      },
+                                      "runAsNonRoot": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUser": {
+                                        "type": "integer"
+                                      },
+                                      "seLinuxOptions": {
+                                        "properties": {
+                                          "level": {
+                                            "type": "string"
+                                          },
+                                          "role": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          },
+                                          "user": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "seccompProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "windowsOptions": {
+                                        "properties": {
+                                          "gmsaCredentialSpec": {
+                                            "type": "string"
+                                          },
+                                          "gmsaCredentialSpecName": {
+                                            "type": "string"
+                                          },
+                                          "hostProcess": {
+                                            "type": "boolean"
+                                          },
+                                          "runAsUserName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "startupProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stdin": {
+                                    "type": "boolean"
+                                  },
+                                  "stdinOnce": {
+                                    "type": "boolean"
+                                  },
+                                  "targetContainerName": {
+                                    "type": "string"
+                                  },
+                                  "terminationMessagePath": {
+                                    "type": "string"
+                                  },
+                                  "terminationMessagePolicy": {
+                                    "type": "string"
+                                  },
+                                  "tty": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeDevices": {
+                                    "items": {
+                                      "properties": {
+                                        "devicePath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "mountPropagation": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        },
+                                        "subPath": {
+                                          "type": "string"
+                                        },
+                                        "subPathExpr": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "workingDir": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "hostAliases": {
+                              "items": {
+                                "properties": {
+                                  "hostnames": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "ip": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "hostIPC": {
+                              "type": "boolean"
+                            },
+                            "hostNetwork": {
+                              "type": "boolean"
+                            },
+                            "hostPID": {
+                              "type": "boolean"
+                            },
+                            "hostUsers": {
+                              "type": "boolean"
+                            },
+                            "hostname": {
+                              "type": "string"
+                            },
+                            "imagePullSecrets": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "initContainers": {
+                              "items": {
+                                "properties": {
+                                  "args": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "env": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "valueFrom": {
+                                          "properties": {
+                                            "configMapKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "fieldRef": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldPath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "resourceFieldRef": {
+                                              "properties": {
+                                                "containerName": {
+                                                  "type": "string"
+                                                },
+                                                "divisor": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "resource": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "secretKeyRef": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "envFrom": {
+                                    "items": {
+                                      "properties": {
+                                        "configMapRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "prefix": {
+                                          "type": "string"
+                                        },
+                                        "secretRef": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imagePullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "lifecycle": {
+                                    "properties": {
+                                      "postStart": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "preStop": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "items": {
+                                                  "properties": {
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "value": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "sleep": {
+                                            "properties": {
+                                              "seconds": {
+                                                "type": "integer"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "stopSignal": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "livenessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ports": {
+                                    "items": {
+                                      "properties": {
+                                        "containerPort": {
+                                          "type": "integer"
+                                        },
+                                        "hostIP": {
+                                          "type": "string"
+                                        },
+                                        "hostPort": {
+                                          "type": "integer"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "protocol": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "readinessProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "resizePolicy": {
+                                    "items": {
+                                      "properties": {
+                                        "resourceName": {
+                                          "type": "string"
+                                        },
+                                        "restartPolicy": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartPolicy": {
+                                    "type": "string"
+                                  },
+                                  "securityContext": {
+                                    "properties": {
+                                      "allowPrivilegeEscalation": {
+                                        "type": "boolean"
+                                      },
+                                      "appArmorProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "capabilities": {
+                                        "properties": {
+                                          "add": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "drop": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "privileged": {
+                                        "type": "boolean"
+                                      },
+                                      "procMount": {
+                                        "type": "string"
+                                      },
+                                      "readOnlyRootFilesystem": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsGroup": {
+                                        "type": "integer"
+                                      },
+                                      "runAsNonRoot": {
+                                        "type": "boolean"
+                                      },
+                                      "runAsUser": {
+                                        "type": "integer"
+                                      },
+                                      "seLinuxOptions": {
+                                        "properties": {
+                                          "level": {
+                                            "type": "string"
+                                          },
+                                          "role": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          },
+                                          "user": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "seccompProfile": {
+                                        "properties": {
+                                          "localhostProfile": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "windowsOptions": {
+                                        "properties": {
+                                          "gmsaCredentialSpec": {
+                                            "type": "string"
+                                          },
+                                          "gmsaCredentialSpecName": {
+                                            "type": "string"
+                                          },
+                                          "hostProcess": {
+                                            "type": "boolean"
+                                          },
+                                          "runAsUserName": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "startupProbe": {
+                                    "properties": {
+                                      "exec": {
+                                        "properties": {
+                                          "command": {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "failureThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "grpc": {
+                                        "properties": {
+                                          "port": {
+                                            "type": "integer"
+                                          },
+                                          "service": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "httpGet": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "httpHeaders": {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "scheme": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "initialDelaySeconds": {
+                                        "type": "integer"
+                                      },
+                                      "periodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "successThreshold": {
+                                        "type": "integer"
+                                      },
+                                      "tcpSocket": {
+                                        "properties": {
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "port": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "string"
+                                              }
+                                            ],
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminationGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "timeoutSeconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stdin": {
+                                    "type": "boolean"
+                                  },
+                                  "stdinOnce": {
+                                    "type": "boolean"
+                                  },
+                                  "terminationMessagePath": {
+                                    "type": "string"
+                                  },
+                                  "terminationMessagePolicy": {
+                                    "type": "string"
+                                  },
+                                  "tty": {
+                                    "type": "boolean"
+                                  },
+                                  "volumeDevices": {
+                                    "items": {
+                                      "properties": {
+                                        "devicePath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "mountPropagation": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        },
+                                        "subPath": {
+                                          "type": "string"
+                                        },
+                                        "subPathExpr": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "workingDir": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "nodeName": {
+                              "type": "string"
+                            },
+                            "nodeSelector": {
+                              "additionalProperties": {
+                                "type": "string"
+                              },
+                              "type": "object"
+                            },
+                            "os": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "overhead": {
+                              "additionalProperties": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "type": "object"
+                            },
+                            "preemptionPolicy": {
+                              "type": "string"
+                            },
+                            "priority": {
+                              "type": "integer"
+                            },
+                            "priorityClassName": {
+                              "type": "string"
+                            },
+                            "readinessGates": {
+                              "items": {
+                                "properties": {
+                                  "conditionType": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "resourceClaims": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resourceClaimName": {
+                                    "type": "string"
+                                  },
+                                  "resourceClaimTemplateName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "resources": {
+                              "properties": {
+                                "claims": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "limits": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                },
+                                "requests": {
+                                  "additionalProperties": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "type": "object"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "restartPolicy": {
+                              "type": "string"
+                            },
+                            "runtimeClassName": {
+                              "type": "string"
+                            },
+                            "schedulerName": {
+                              "type": "string"
+                            },
+                            "schedulingGates": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "securityContext": {
+                              "properties": {
+                                "appArmorProfile": {
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "fsGroup": {
+                                  "type": "integer"
+                                },
+                                "fsGroupChangePolicy": {
+                                  "type": "string"
+                                },
+                                "runAsGroup": {
+                                  "type": "integer"
+                                },
+                                "runAsNonRoot": {
+                                  "type": "boolean"
+                                },
+                                "runAsUser": {
+                                  "type": "integer"
+                                },
+                                "seLinuxChangePolicy": {
+                                  "type": "string"
+                                },
+                                "seLinuxOptions": {
+                                  "properties": {
+                                    "level": {
+                                      "type": "string"
+                                    },
+                                    "role": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    },
+                                    "user": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "seccompProfile": {
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "supplementalGroups": {
+                                  "items": {
+                                    "type": "integer"
+                                  },
+                                  "type": "array"
+                                },
+                                "supplementalGroupsPolicy": {
+                                  "type": "string"
+                                },
+                                "sysctls": {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                },
+                                "windowsOptions": {
+                                  "properties": {
+                                    "gmsaCredentialSpec": {
+                                      "type": "string"
+                                    },
+                                    "gmsaCredentialSpecName": {
+                                      "type": "string"
+                                    },
+                                    "hostProcess": {
+                                      "type": "boolean"
+                                    },
+                                    "runAsUserName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "serviceAccount": {
+                              "type": "string"
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "setHostnameAsFQDN": {
+                              "type": "boolean"
+                            },
+                            "shareProcessNamespace": {
+                              "type": "boolean"
+                            },
+                            "subdomain": {
+                              "type": "string"
+                            },
+                            "terminationGracePeriodSeconds": {
+                              "type": "integer"
+                            },
+                            "tolerations": {
+                              "items": {
+                                "properties": {
+                                  "effect": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "type": "string"
+                                  },
+                                  "tolerationSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "topologySpreadConstraints": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "maxSkew": {
+                                    "type": "integer"
+                                  },
+                                  "minDomains": {
+                                    "type": "integer"
+                                  },
+                                  "nodeAffinityPolicy": {
+                                    "type": "string"
+                                  },
+                                  "nodeTaintsPolicy": {
+                                    "type": "string"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  },
+                                  "whenUnsatisfiable": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "volumes": {
+                              "items": {
+                                "properties": {
+                                  "awsElasticBlockStore": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "partition": {
+                                        "type": "integer"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "volumeID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "azureDisk": {
+                                    "properties": {
+                                      "cachingMode": {
+                                        "type": "string"
+                                      },
+                                      "diskName": {
+                                        "type": "string"
+                                      },
+                                      "diskURI": {
+                                        "type": "string"
+                                      },
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "azureFile": {
+                                    "properties": {
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretName": {
+                                        "type": "string"
+                                      },
+                                      "shareName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "cephfs": {
+                                    "properties": {
+                                      "monitors": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretFile": {
+                                        "type": "string"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "cinder": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "volumeID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "configMap": {
+                                    "properties": {
+                                      "defaultMode": {
+                                        "type": "integer"
+                                      },
+                                      "items": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "mode": {
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "csi": {
+                                    "properties": {
+                                      "driver": {
+                                        "type": "string"
+                                      },
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "nodePublishSecretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "volumeAttributes": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "downwardAPI": {
+                                    "properties": {
+                                      "defaultMode": {
+                                        "type": "integer"
+                                      },
+                                      "items": {
+                                        "items": {
+                                          "properties": {
+                                            "fieldRef": {
+                                              "properties": {
+                                                "apiVersion": {
+                                                  "type": "string"
+                                                },
+                                                "fieldPath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "mode": {
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "resourceFieldRef": {
+                                              "properties": {
+                                                "containerName": {
+                                                  "type": "string"
+                                                },
+                                                "divisor": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "integer"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    }
+                                                  ],
+                                                  "x-kubernetes-int-or-string": true
+                                                },
+                                                "resource": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "emptyDir": {
+                                    "properties": {
+                                      "medium": {
+                                        "type": "string"
+                                      },
+                                      "sizeLimit": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "ephemeral": {
+                                    "properties": {
+                                      "volumeClaimTemplate": {
+                                        "properties": {
+                                          "metadata": {
+                                            "properties": {
+                                              "annotations": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "creationTimestamp": {
+                                                "type": "string"
+                                              },
+                                              "deletionGracePeriodSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "deletionTimestamp": {
+                                                "type": "string"
+                                              },
+                                              "finalizers": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "generateName": {
+                                                "type": "string"
+                                              },
+                                              "generation": {
+                                                "type": "integer"
+                                              },
+                                              "labels": {
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                },
+                                                "type": "object"
+                                              },
+                                              "managedFields": {
+                                                "items": {
+                                                  "properties": {
+                                                    "apiVersion": {
+                                                      "type": "string"
+                                                    },
+                                                    "fieldsType": {
+                                                      "type": "string"
+                                                    },
+                                                    "fieldsV1": {
+                                                      "type": "object"
+                                                    },
+                                                    "manager": {
+                                                      "type": "string"
+                                                    },
+                                                    "operation": {
+                                                      "type": "string"
+                                                    },
+                                                    "subresource": {
+                                                      "type": "string"
+                                                    },
+                                                    "time": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "namespace": {
+                                                "type": "string"
+                                              },
+                                              "ownerReferences": {
+                                                "items": {
+                                                  "properties": {
+                                                    "apiVersion": {
+                                                      "type": "string"
+                                                    },
+                                                    "blockOwnerDeletion": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "controller": {
+                                                      "type": "boolean"
+                                                    },
+                                                    "kind": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "uid": {
+                                                      "type": "string"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "type": "array"
+                                              },
+                                              "resourceVersion": {
+                                                "type": "string"
+                                              },
+                                              "selfLink": {
+                                                "type": "string"
+                                              },
+                                              "uid": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "spec": {
+                                            "properties": {
+                                              "accessModes": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              "dataSource": {
+                                                "properties": {
+                                                  "apiGroup": {
+                                                    "type": "string"
+                                                  },
+                                                  "kind": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "dataSourceRef": {
+                                                "properties": {
+                                                  "apiGroup": {
+                                                    "type": "string"
+                                                  },
+                                                  "kind": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "namespace": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "resources": {
+                                                "properties": {
+                                                  "limits": {
+                                                    "additionalProperties": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "requests": {
+                                                    "additionalProperties": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "string"
+                                                        }
+                                                      ],
+                                                      "x-kubernetes-int-or-string": true
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "selector": {
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "type": "array"
+                                                        }
+                                                      },
+                                                      "type": "object",
+                                                      "additionalProperties": false
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  "matchLabels": {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "storageClassName": {
+                                                "type": "string"
+                                              },
+                                              "volumeAttributesClassName": {
+                                                "type": "string"
+                                              },
+                                              "volumeMode": {
+                                                "type": "string"
+                                              },
+                                              "volumeName": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "fc": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "lun": {
+                                        "type": "integer"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "targetWWNs": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "wwids": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "flexVolume": {
+                                    "properties": {
+                                      "driver": {
+                                        "type": "string"
+                                      },
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "options": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "flocker": {
+                                    "properties": {
+                                      "datasetName": {
+                                        "type": "string"
+                                      },
+                                      "datasetUUID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "gcePersistentDisk": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "partition": {
+                                        "type": "integer"
+                                      },
+                                      "pdName": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "gitRepo": {
+                                    "properties": {
+                                      "directory": {
+                                        "type": "string"
+                                      },
+                                      "repository": {
+                                        "type": "string"
+                                      },
+                                      "revision": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "glusterfs": {
+                                    "properties": {
+                                      "endpoints": {
+                                        "type": "string"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "hostPath": {
+                                    "properties": {
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "image": {
+                                    "properties": {
+                                      "pullPolicy": {
+                                        "type": "string"
+                                      },
+                                      "reference": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "iscsi": {
+                                    "properties": {
+                                      "chapAuthDiscovery": {
+                                        "type": "boolean"
+                                      },
+                                      "chapAuthSession": {
+                                        "type": "boolean"
+                                      },
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "initiatorName": {
+                                        "type": "string"
+                                      },
+                                      "iqn": {
+                                        "type": "string"
+                                      },
+                                      "iscsiInterface": {
+                                        "type": "string"
+                                      },
+                                      "lun": {
+                                        "type": "integer"
+                                      },
+                                      "portals": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "targetPortal": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "nfs": {
+                                    "properties": {
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "server": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "persistentVolumeClaim": {
+                                    "properties": {
+                                      "claimName": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "photonPersistentDisk": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "pdID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "portworxVolume": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "volumeID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "projected": {
+                                    "properties": {
+                                      "defaultMode": {
+                                        "type": "integer"
+                                      },
+                                      "sources": {
+                                        "items": {
+                                          "properties": {
+                                            "clusterTrustBundle": {
+                                              "properties": {
+                                                "labelSelector": {
+                                                  "properties": {
+                                                    "matchExpressions": {
+                                                      "items": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string"
+                                                          },
+                                                          "operator": {
+                                                            "type": "string"
+                                                          },
+                                                          "values": {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "type": "array"
+                                                    },
+                                                    "matchLabels": {
+                                                      "additionalProperties": {
+                                                        "type": "string"
+                                                      },
+                                                      "type": "object"
+                                                    }
+                                                  },
+                                                  "type": "object",
+                                                  "additionalProperties": false
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                },
+                                                "path": {
+                                                  "type": "string"
+                                                },
+                                                "signerName": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "configMap": {
+                                              "properties": {
+                                                "items": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "mode": {
+                                                        "type": "integer"
+                                                      },
+                                                      "path": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "downwardAPI": {
+                                              "properties": {
+                                                "items": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "fieldRef": {
+                                                        "properties": {
+                                                          "apiVersion": {
+                                                            "type": "string"
+                                                          },
+                                                          "fieldPath": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      },
+                                                      "mode": {
+                                                        "type": "integer"
+                                                      },
+                                                      "path": {
+                                                        "type": "string"
+                                                      },
+                                                      "resourceFieldRef": {
+                                                        "properties": {
+                                                          "containerName": {
+                                                            "type": "string"
+                                                          },
+                                                          "divisor": {
+                                                            "anyOf": [
+                                                              {
+                                                                "type": "integer"
+                                                              },
+                                                              {
+                                                                "type": "string"
+                                                              }
+                                                            ],
+                                                            "x-kubernetes-int-or-string": true
+                                                          },
+                                                          "resource": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "secret": {
+                                              "properties": {
+                                                "items": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "mode": {
+                                                        "type": "integer"
+                                                      },
+                                                      "path": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object",
+                                                    "additionalProperties": false
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "optional": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "serviceAccountToken": {
+                                              "properties": {
+                                                "audience": {
+                                                  "type": "string"
+                                                },
+                                                "expirationSeconds": {
+                                                  "type": "integer"
+                                                },
+                                                "path": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "quobyte": {
+                                    "properties": {
+                                      "group": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "registry": {
+                                        "type": "string"
+                                      },
+                                      "tenant": {
+                                        "type": "string"
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      },
+                                      "volume": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "rbd": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "image": {
+                                        "type": "string"
+                                      },
+                                      "keyring": {
+                                        "type": "string"
+                                      },
+                                      "monitors": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "pool": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "user": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "scaleIO": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "gateway": {
+                                        "type": "string"
+                                      },
+                                      "protectionDomain": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "sslEnabled": {
+                                        "type": "boolean"
+                                      },
+                                      "storageMode": {
+                                        "type": "string"
+                                      },
+                                      "storagePool": {
+                                        "type": "string"
+                                      },
+                                      "system": {
+                                        "type": "string"
+                                      },
+                                      "volumeName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "secret": {
+                                    "properties": {
+                                      "defaultMode": {
+                                        "type": "integer"
+                                      },
+                                      "items": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "mode": {
+                                              "type": "integer"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "optional": {
+                                        "type": "boolean"
+                                      },
+                                      "secretName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "storageos": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "readOnly": {
+                                        "type": "boolean"
+                                      },
+                                      "secretRef": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "volumeName": {
+                                        "type": "string"
+                                      },
+                                      "volumeNamespace": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "vsphereVolume": {
+                                    "properties": {
+                                      "fsType": {
+                                        "type": "string"
+                                      },
+                                      "storagePolicyID": {
+                                        "type": "string"
+                                      },
+                                      "storagePolicyName": {
+                                        "type": "string"
+                                      },
+                                      "volumePath": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "status": {
+                          "properties": {
+                            "conditions": {
+                              "items": {
+                                "properties": {
+                                  "lastProbeTime": {
+                                    "type": "string"
+                                  },
+                                  "lastTransitionTime": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "observedGeneration": {
+                                    "type": "integer"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "status": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "containerStatuses": {
+                              "items": {
+                                "properties": {
+                                  "allocatedResources": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "allocatedResourcesStatus": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "resources": {
+                                          "items": {
+                                            "properties": {
+                                              "health": {
+                                                "type": "string"
+                                              },
+                                              "resourceID": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imageID": {
+                                    "type": "string"
+                                  },
+                                  "lastState": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ready": {
+                                    "type": "boolean"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartCount": {
+                                    "type": "integer"
+                                  },
+                                  "started": {
+                                    "type": "boolean"
+                                  },
+                                  "state": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "properties": {
+                                      "linux": {
+                                        "properties": {
+                                          "gid": {
+                                            "type": "integer"
+                                          },
+                                          "supplementalGroups": {
+                                            "items": {
+                                              "type": "integer"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "uid": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "ephemeralContainerStatuses": {
+                              "items": {
+                                "properties": {
+                                  "allocatedResources": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "allocatedResourcesStatus": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "resources": {
+                                          "items": {
+                                            "properties": {
+                                              "health": {
+                                                "type": "string"
+                                              },
+                                              "resourceID": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imageID": {
+                                    "type": "string"
+                                  },
+                                  "lastState": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ready": {
+                                    "type": "boolean"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartCount": {
+                                    "type": "integer"
+                                  },
+                                  "started": {
+                                    "type": "boolean"
+                                  },
+                                  "state": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "properties": {
+                                      "linux": {
+                                        "properties": {
+                                          "gid": {
+                                            "type": "integer"
+                                          },
+                                          "supplementalGroups": {
+                                            "items": {
+                                              "type": "integer"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "uid": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostIPs": {
+                              "items": {
+                                "properties": {
+                                  "ip": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "initContainerStatuses": {
+                              "items": {
+                                "properties": {
+                                  "allocatedResources": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "type": "object"
+                                  },
+                                  "allocatedResourcesStatus": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "resources": {
+                                          "items": {
+                                            "properties": {
+                                              "health": {
+                                                "type": "string"
+                                              },
+                                              "resourceID": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "image": {
+                                    "type": "string"
+                                  },
+                                  "imageID": {
+                                    "type": "string"
+                                  },
+                                  "lastState": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "ready": {
+                                    "type": "boolean"
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "claims": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "request": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "restartCount": {
+                                    "type": "integer"
+                                  },
+                                  "started": {
+                                    "type": "boolean"
+                                  },
+                                  "state": {
+                                    "properties": {
+                                      "running": {
+                                        "properties": {
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "terminated": {
+                                        "properties": {
+                                          "containerID": {
+                                            "type": "string"
+                                          },
+                                          "exitCode": {
+                                            "type": "integer"
+                                          },
+                                          "finishedAt": {
+                                            "type": "string"
+                                          },
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          },
+                                          "signal": {
+                                            "type": "integer"
+                                          },
+                                          "startedAt": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "waiting": {
+                                        "properties": {
+                                          "message": {
+                                            "type": "string"
+                                          },
+                                          "reason": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "stopSignal": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "properties": {
+                                      "linux": {
+                                        "properties": {
+                                          "gid": {
+                                            "type": "integer"
+                                          },
+                                          "supplementalGroups": {
+                                            "items": {
+                                              "type": "integer"
+                                            },
+                                            "type": "array"
+                                          },
+                                          "uid": {
+                                            "type": "integer"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "volumeMounts": {
+                                    "items": {
+                                      "properties": {
+                                        "mountPath": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "readOnly": {
+                                          "type": "boolean"
+                                        },
+                                        "recursiveReadOnly": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "message": {
+                              "type": "string"
+                            },
+                            "nominatedNodeName": {
+                              "type": "string"
+                            },
+                            "observedGeneration": {
+                              "type": "integer"
+                            },
+                            "phase": {
+                              "type": "string"
+                            },
+                            "podIP": {
+                              "type": "string"
+                            },
+                            "podIPs": {
+                              "items": {
+                                "properties": {
+                                  "ip": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "qosClass": {
+                              "type": "string"
+                            },
+                            "reason": {
+                              "type": "string"
+                            },
+                            "resize": {
+                              "type": "string"
+                            },
+                            "resourceClaimStatuses": {
+                              "items": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "resourceClaimName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "startTime": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "replicas": {
+                      "type": "integer"
+                    },
+                    "resource": {
+                      "properties": {
+                        "cpu": {
+                          "type": "number"
+                        },
+                        "ephemeralStorage": {
+                          "type": "string"
+                        },
+                        "memory": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "abortTimestamp": {
+          "type": "string"
+        },
+        "blueGreenState": {
+          "enum": [
+            "ACTIVE_BLUE",
+            "ACTIVE_GREEN",
+            "INITIALIZING_BLUE",
+            "SAVEPOINTING_BLUE",
+            "SAVEPOINTING_GREEN",
+            "TRANSITIONING_TO_BLUE",
+            "TRANSITIONING_TO_GREEN"
+          ],
+          "type": "string"
+        },
+        "deploymentReadyTimestamp": {
+          "type": "string"
+        },
+        "error": {
+          "type": "string"
+        },
+        "jobStatus": {
+          "properties": {
+            "checkpointInfo": {
+              "properties": {
+                "formatType": {
+                  "enum": [
+                    "FULL",
+                    "INCREMENTAL",
+                    "UNKNOWN"
+                  ],
+                  "type": "string"
+                },
+                "lastCheckpoint": {
+                  "properties": {
+                    "formatType": {
+                      "enum": [
+                        "FULL",
+                        "INCREMENTAL",
+                        "UNKNOWN"
+                      ],
+                      "type": "string"
+                    },
+                    "timeStamp": {
+                      "type": "integer"
+                    },
+                    "triggerNonce": {
+                      "type": "integer"
+                    },
+                    "triggerType": {
+                      "enum": [
+                        "MANUAL",
+                        "PERIODIC",
+                        "UNKNOWN",
+                        "UPGRADE"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "lastPeriodicCheckpointTimestamp": {
+                  "type": "integer"
+                },
+                "triggerId": {
+                  "type": "string"
+                },
+                "triggerTimestamp": {
+                  "type": "integer"
+                },
+                "triggerType": {
+                  "enum": [
+                    "MANUAL",
+                    "PERIODIC",
+                    "UNKNOWN",
+                    "UPGRADE"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "jobId": {
+              "type": "string"
+            },
+            "jobName": {
+              "type": "string"
+            },
+            "savepointInfo": {
+              "properties": {
+                "formatType": {
+                  "enum": [
+                    "CANONICAL",
+                    "NATIVE",
+                    "UNKNOWN"
+                  ],
+                  "type": "string"
+                },
+                "lastPeriodicSavepointTimestamp": {
+                  "type": "integer"
+                },
+                "lastSavepoint": {
+                  "properties": {
+                    "formatType": {
+                      "enum": [
+                        "CANONICAL",
+                        "NATIVE",
+                        "UNKNOWN"
+                      ],
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    },
+                    "timeStamp": {
+                      "type": "integer"
+                    },
+                    "triggerNonce": {
+                      "type": "integer"
+                    },
+                    "triggerType": {
+                      "enum": [
+                        "MANUAL",
+                        "PERIODIC",
+                        "UNKNOWN",
+                        "UPGRADE"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "savepointHistory": {
+                  "items": {
+                    "properties": {
+                      "formatType": {
+                        "enum": [
+                          "CANONICAL",
+                          "NATIVE",
+                          "UNKNOWN"
+                        ],
+                        "type": "string"
+                      },
+                      "location": {
+                        "type": "string"
+                      },
+                      "timeStamp": {
+                        "type": "integer"
+                      },
+                      "triggerNonce": {
+                        "type": "integer"
+                      },
+                      "triggerType": {
+                        "enum": [
+                          "MANUAL",
+                          "PERIODIC",
+                          "UNKNOWN",
+                          "UPGRADE"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "triggerId": {
+                  "type": "string"
+                },
+                "triggerTimestamp": {
+                  "type": "integer"
+                },
+                "triggerType": {
+                  "enum": [
+                    "MANUAL",
+                    "PERIODIC",
+                    "UNKNOWN",
+                    "UPGRADE"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "startTime": {
+              "type": "string"
+            },
+            "state": {
+              "enum": [
+                "CANCELED",
+                "CANCELLING",
+                "CREATED",
+                "FAILED",
+                "FAILING",
+                "FINISHED",
+                "INITIALIZING",
+                "RECONCILING",
+                "RESTARTING",
+                "RUNNING",
+                "SUSPENDED"
+              ],
+              "type": "string"
+            },
+            "updateTime": {
+              "type": "string"
+            },
+            "upgradeSavepointPath": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "lastReconciledSpec": {
+          "type": "string"
+        },
+        "lastReconciledTimestamp": {
+          "type": "string"
+        },
+        "savepointTriggerId": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/master-standalone/flinkdeployment_v1beta1.json
+++ b/master-standalone/flinkdeployment_v1beta1.json
@@ -1,0 +1,18397 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "flinkConfiguration": {
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "flinkVersion": {
+          "enum": [
+            "v1_13",
+            "v1_14",
+            "v1_15",
+            "v1_16",
+            "v1_17",
+            "v1_18",
+            "v1_19",
+            "v1_20",
+            "v2_0",
+            "v2_1",
+            "v2_2"
+          ],
+          "type": "string"
+        },
+        "image": {
+          "type": "string"
+        },
+        "imagePullPolicy": {
+          "type": "string"
+        },
+        "ingress": {
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "className": {
+              "type": "string"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "template": {
+              "type": "string"
+            },
+            "tls": {
+              "items": {
+                "properties": {
+                  "hosts": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "secretName": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "additionalProperties": false
+              },
+              "type": "array"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "job": {
+          "properties": {
+            "allowNonRestoredState": {
+              "type": "boolean"
+            },
+            "args": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "autoscalerResetNonce": {
+              "type": "integer"
+            },
+            "checkpointTriggerNonce": {
+              "type": "integer"
+            },
+            "entryClass": {
+              "type": "string"
+            },
+            "initialSavepointPath": {
+              "type": "string"
+            },
+            "jarURI": {
+              "type": "string"
+            },
+            "parallelism": {
+              "type": "integer"
+            },
+            "savepointRedeployNonce": {
+              "type": "integer"
+            },
+            "savepointTriggerNonce": {
+              "type": "integer"
+            },
+            "state": {
+              "enum": [
+                "running",
+                "suspended"
+              ],
+              "type": "string"
+            },
+            "upgradeMode": {
+              "enum": [
+                "last-state",
+                "savepoint",
+                "stateless"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "jobManager": {
+          "properties": {
+            "podTemplate": {
+              "properties": {
+                "apiVersion": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "metadata": {
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "creationTimestamp": {
+                      "type": "string"
+                    },
+                    "deletionGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "deletionTimestamp": {
+                      "type": "string"
+                    },
+                    "finalizers": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "generateName": {
+                      "type": "string"
+                    },
+                    "generation": {
+                      "type": "integer"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "managedFields": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "fieldsType": {
+                            "type": "string"
+                          },
+                          "fieldsV1": {
+                            "type": "object"
+                          },
+                          "manager": {
+                            "type": "string"
+                          },
+                          "operation": {
+                            "type": "string"
+                          },
+                          "subresource": {
+                            "type": "string"
+                          },
+                          "time": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    },
+                    "ownerReferences": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "blockOwnerDeletion": {
+                            "type": "boolean"
+                          },
+                          "controller": {
+                            "type": "boolean"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "uid": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "resourceVersion": {
+                      "type": "string"
+                    },
+                    "selfLink": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spec": {
+                  "properties": {
+                    "activeDeadlineSeconds": {
+                      "type": "integer"
+                    },
+                    "affinity": {
+                      "properties": {
+                        "nodeAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "preference": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "properties": {
+                                "nodeSelectorTerms": {
+                                  "items": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "podAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "podAntiAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "automountServiceAccountToken": {
+                      "type": "boolean"
+                    },
+                    "containers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "dnsConfig": {
+                      "properties": {
+                        "nameservers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "options": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "searches": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "dnsPolicy": {
+                      "type": "string"
+                    },
+                    "enableServiceLinks": {
+                      "type": "boolean"
+                    },
+                    "ephemeralContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "targetContainerName": {
+                            "type": "string"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "hostAliases": {
+                      "items": {
+                        "properties": {
+                          "hostnames": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "hostIPC": {
+                      "type": "boolean"
+                    },
+                    "hostNetwork": {
+                      "type": "boolean"
+                    },
+                    "hostPID": {
+                      "type": "boolean"
+                    },
+                    "hostUsers": {
+                      "type": "boolean"
+                    },
+                    "hostname": {
+                      "type": "string"
+                    },
+                    "imagePullSecrets": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "initContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "nodeName": {
+                      "type": "string"
+                    },
+                    "nodeSelector": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "os": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "overhead": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    },
+                    "preemptionPolicy": {
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "integer"
+                    },
+                    "priorityClassName": {
+                      "type": "string"
+                    },
+                    "readinessGates": {
+                      "items": {
+                        "properties": {
+                          "conditionType": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "resourceClaims": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "resourceClaimName": {
+                            "type": "string"
+                          },
+                          "resourceClaimTemplateName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "resources": {
+                      "properties": {
+                        "claims": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "request": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "limits": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "requests": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "restartPolicy": {
+                      "type": "string"
+                    },
+                    "runtimeClassName": {
+                      "type": "string"
+                    },
+                    "schedulerName": {
+                      "type": "string"
+                    },
+                    "schedulingGates": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "securityContext": {
+                      "properties": {
+                        "appArmorProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "fsGroup": {
+                          "type": "integer"
+                        },
+                        "fsGroupChangePolicy": {
+                          "type": "string"
+                        },
+                        "runAsGroup": {
+                          "type": "integer"
+                        },
+                        "runAsNonRoot": {
+                          "type": "boolean"
+                        },
+                        "runAsUser": {
+                          "type": "integer"
+                        },
+                        "seLinuxChangePolicy": {
+                          "type": "string"
+                        },
+                        "seLinuxOptions": {
+                          "properties": {
+                            "level": {
+                              "type": "string"
+                            },
+                            "role": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "seccompProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "supplementalGroups": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "supplementalGroupsPolicy": {
+                          "type": "string"
+                        },
+                        "sysctls": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "windowsOptions": {
+                          "properties": {
+                            "gmsaCredentialSpec": {
+                              "type": "string"
+                            },
+                            "gmsaCredentialSpecName": {
+                              "type": "string"
+                            },
+                            "hostProcess": {
+                              "type": "boolean"
+                            },
+                            "runAsUserName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "serviceAccount": {
+                      "type": "string"
+                    },
+                    "serviceAccountName": {
+                      "type": "string"
+                    },
+                    "setHostnameAsFQDN": {
+                      "type": "boolean"
+                    },
+                    "shareProcessNamespace": {
+                      "type": "boolean"
+                    },
+                    "subdomain": {
+                      "type": "string"
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "tolerations": {
+                      "items": {
+                        "properties": {
+                          "effect": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "tolerationSeconds": {
+                            "type": "integer"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "topologySpreadConstraints": {
+                      "items": {
+                        "properties": {
+                          "labelSelector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "matchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "maxSkew": {
+                            "type": "integer"
+                          },
+                          "minDomains": {
+                            "type": "integer"
+                          },
+                          "nodeAffinityPolicy": {
+                            "type": "string"
+                          },
+                          "nodeTaintsPolicy": {
+                            "type": "string"
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          },
+                          "whenUnsatisfiable": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "volumes": {
+                      "items": {
+                        "properties": {
+                          "awsElasticBlockStore": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azureDisk": {
+                            "properties": {
+                              "cachingMode": {
+                                "type": "string"
+                              },
+                              "diskName": {
+                                "type": "string"
+                              },
+                              "diskURI": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azureFile": {
+                            "properties": {
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              },
+                              "shareName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "cephfs": {
+                            "properties": {
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretFile": {
+                                "type": "string"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "cinder": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "configMap": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "csi": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "nodePublishSecretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeAttributes": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "downwardAPI": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "emptyDir": {
+                            "properties": {
+                              "medium": {
+                                "type": "string"
+                              },
+                              "sizeLimit": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "ephemeral": {
+                            "properties": {
+                              "volumeClaimTemplate": {
+                                "properties": {
+                                  "metadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "creationTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "deletionGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "deletionTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "finalizers": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "generateName": {
+                                        "type": "string"
+                                      },
+                                      "generation": {
+                                        "type": "integer"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "managedFields": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldsType": {
+                                              "type": "string"
+                                            },
+                                            "fieldsV1": {
+                                              "type": "object"
+                                            },
+                                            "manager": {
+                                              "type": "string"
+                                            },
+                                            "operation": {
+                                              "type": "string"
+                                            },
+                                            "subresource": {
+                                              "type": "string"
+                                            },
+                                            "time": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      },
+                                      "ownerReferences": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "blockOwnerDeletion": {
+                                              "type": "boolean"
+                                            },
+                                            "controller": {
+                                              "type": "boolean"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "uid": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "resourceVersion": {
+                                        "type": "string"
+                                      },
+                                      "selfLink": {
+                                        "type": "string"
+                                      },
+                                      "uid": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "spec": {
+                                    "properties": {
+                                      "accessModes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "dataSource": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "dataSourceRef": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "resources": {
+                                        "properties": {
+                                          "limits": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          },
+                                          "requests": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "selector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "storageClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeAttributesClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeMode": {
+                                        "type": "string"
+                                      },
+                                      "volumeName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "fc": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "targetWWNs": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "wwids": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "flexVolume": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "options": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "flocker": {
+                            "properties": {
+                              "datasetName": {
+                                "type": "string"
+                              },
+                              "datasetUUID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "gcePersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "pdName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "gitRepo": {
+                            "properties": {
+                              "directory": {
+                                "type": "string"
+                              },
+                              "repository": {
+                                "type": "string"
+                              },
+                              "revision": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "glusterfs": {
+                            "properties": {
+                              "endpoints": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "hostPath": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "image": {
+                            "properties": {
+                              "pullPolicy": {
+                                "type": "string"
+                              },
+                              "reference": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "iscsi": {
+                            "properties": {
+                              "chapAuthDiscovery": {
+                                "type": "boolean"
+                              },
+                              "chapAuthSession": {
+                                "type": "boolean"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "initiatorName": {
+                                "type": "string"
+                              },
+                              "iqn": {
+                                "type": "string"
+                              },
+                              "iscsiInterface": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "portals": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "targetPortal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "nfs": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "server": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "persistentVolumeClaim": {
+                            "properties": {
+                              "claimName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "photonPersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "pdID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "portworxVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "projected": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "sources": {
+                                "items": {
+                                  "properties": {
+                                    "clusterTrustBundle": {
+                                      "properties": {
+                                        "labelSelector": {
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "matchLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "signerName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "configMap": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "downwardAPI": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "fieldRef": {
+                                                "properties": {
+                                                  "apiVersion": {
+                                                    "type": "string"
+                                                  },
+                                                  "fieldPath": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "resourceFieldRef": {
+                                                "properties": {
+                                                  "containerName": {
+                                                    "type": "string"
+                                                  },
+                                                  "divisor": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "resource": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secret": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "serviceAccountToken": {
+                                      "properties": {
+                                        "audience": {
+                                          "type": "string"
+                                        },
+                                        "expirationSeconds": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "quobyte": {
+                            "properties": {
+                              "group": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "registry": {
+                                "type": "string"
+                              },
+                              "tenant": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              },
+                              "volume": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "rbd": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "keyring": {
+                                "type": "string"
+                              },
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "pool": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "scaleIO": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "gateway": {
+                                "type": "string"
+                              },
+                              "protectionDomain": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "sslEnabled": {
+                                "type": "boolean"
+                              },
+                              "storageMode": {
+                                "type": "string"
+                              },
+                              "storagePool": {
+                                "type": "string"
+                              },
+                              "system": {
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "secret": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "storageos": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              },
+                              "volumeNamespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "vsphereVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "storagePolicyID": {
+                                "type": "string"
+                              },
+                              "storagePolicyName": {
+                                "type": "string"
+                              },
+                              "volumePath": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "status": {
+                  "properties": {
+                    "conditions": {
+                      "items": {
+                        "properties": {
+                          "lastProbeTime": {
+                            "type": "string"
+                          },
+                          "lastTransitionTime": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "observedGeneration": {
+                            "type": "integer"
+                          },
+                          "reason": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "containerStatuses": {
+                      "items": {
+                        "properties": {
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "allocatedResourcesStatus": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "resources": {
+                                  "items": {
+                                    "properties": {
+                                      "health": {
+                                        "type": "string"
+                                      },
+                                      "resourceID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "containerID": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imageID": {
+                            "type": "string"
+                          },
+                          "lastState": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ready": {
+                            "type": "boolean"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartCount": {
+                            "type": "integer"
+                          },
+                          "started": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "properties": {
+                              "linux": {
+                                "properties": {
+                                  "gid": {
+                                    "type": "integer"
+                                  },
+                                  "supplementalGroups": {
+                                    "items": {
+                                      "type": "integer"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "uid": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "ephemeralContainerStatuses": {
+                      "items": {
+                        "properties": {
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "allocatedResourcesStatus": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "resources": {
+                                  "items": {
+                                    "properties": {
+                                      "health": {
+                                        "type": "string"
+                                      },
+                                      "resourceID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "containerID": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imageID": {
+                            "type": "string"
+                          },
+                          "lastState": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ready": {
+                            "type": "boolean"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartCount": {
+                            "type": "integer"
+                          },
+                          "started": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "properties": {
+                              "linux": {
+                                "properties": {
+                                  "gid": {
+                                    "type": "integer"
+                                  },
+                                  "supplementalGroups": {
+                                    "items": {
+                                      "type": "integer"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "uid": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "hostIP": {
+                      "type": "string"
+                    },
+                    "hostIPs": {
+                      "items": {
+                        "properties": {
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "initContainerStatuses": {
+                      "items": {
+                        "properties": {
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "allocatedResourcesStatus": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "resources": {
+                                  "items": {
+                                    "properties": {
+                                      "health": {
+                                        "type": "string"
+                                      },
+                                      "resourceID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "containerID": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imageID": {
+                            "type": "string"
+                          },
+                          "lastState": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ready": {
+                            "type": "boolean"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartCount": {
+                            "type": "integer"
+                          },
+                          "started": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "properties": {
+                              "linux": {
+                                "properties": {
+                                  "gid": {
+                                    "type": "integer"
+                                  },
+                                  "supplementalGroups": {
+                                    "items": {
+                                      "type": "integer"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "uid": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "nominatedNodeName": {
+                      "type": "string"
+                    },
+                    "observedGeneration": {
+                      "type": "integer"
+                    },
+                    "phase": {
+                      "type": "string"
+                    },
+                    "podIP": {
+                      "type": "string"
+                    },
+                    "podIPs": {
+                      "items": {
+                        "properties": {
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "qosClass": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    },
+                    "resize": {
+                      "type": "string"
+                    },
+                    "resourceClaimStatuses": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "resourceClaimName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "startTime": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "replicas": {
+              "type": "integer"
+            },
+            "resource": {
+              "properties": {
+                "cpu": {
+                  "type": "number"
+                },
+                "ephemeralStorage": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "logConfiguration": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "mode": {
+          "enum": [
+            "native",
+            "standalone"
+          ],
+          "type": "string"
+        },
+        "podTemplate": {
+          "properties": {
+            "apiVersion": {
+              "type": "string"
+            },
+            "kind": {
+              "type": "string"
+            },
+            "metadata": {
+              "properties": {
+                "annotations": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "creationTimestamp": {
+                  "type": "string"
+                },
+                "deletionGracePeriodSeconds": {
+                  "type": "integer"
+                },
+                "deletionTimestamp": {
+                  "type": "string"
+                },
+                "finalizers": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "generateName": {
+                  "type": "string"
+                },
+                "generation": {
+                  "type": "integer"
+                },
+                "labels": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "managedFields": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "fieldsType": {
+                        "type": "string"
+                      },
+                      "fieldsV1": {
+                        "type": "object"
+                      },
+                      "manager": {
+                        "type": "string"
+                      },
+                      "operation": {
+                        "type": "string"
+                      },
+                      "subresource": {
+                        "type": "string"
+                      },
+                      "time": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "namespace": {
+                  "type": "string"
+                },
+                "ownerReferences": {
+                  "items": {
+                    "properties": {
+                      "apiVersion": {
+                        "type": "string"
+                      },
+                      "blockOwnerDeletion": {
+                        "type": "boolean"
+                      },
+                      "controller": {
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "uid": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "resourceVersion": {
+                  "type": "string"
+                },
+                "selfLink": {
+                  "type": "string"
+                },
+                "uid": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "spec": {
+              "properties": {
+                "activeDeadlineSeconds": {
+                  "type": "integer"
+                },
+                "affinity": {
+                  "properties": {
+                    "nodeAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "preference": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchFields": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "properties": {
+                            "nodeSelectorTerms": {
+                              "items": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchFields": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "podAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "podAffinityTerm": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "namespaceSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "podAntiAffinity": {
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "podAffinityTerm": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "weight": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "items": {
+                            "properties": {
+                              "labelSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "matchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "mismatchLabelKeys": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "namespaceSelector": {
+                                "properties": {
+                                  "matchExpressions": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "matchLabels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "namespaces": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "topologyKey": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "automountServiceAccountToken": {
+                  "type": "boolean"
+                },
+                "containers": {
+                  "items": {
+                    "properties": {
+                      "args": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "env": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secretKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "envFrom": {
+                        "items": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "type": "string"
+                      },
+                      "lifecycle": {
+                        "properties": {
+                          "postStart": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "sleep": {
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "preStop": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "sleep": {
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "livenessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ports": {
+                        "items": {
+                          "properties": {
+                            "containerPort": {
+                              "type": "integer"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "readinessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resizePolicy": {
+                        "items": {
+                          "properties": {
+                            "resourceName": {
+                              "type": "string"
+                            },
+                            "restartPolicy": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "restartPolicy": {
+                        "type": "string"
+                      },
+                      "securityContext": {
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                          },
+                          "appArmorProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "capabilities": {
+                            "properties": {
+                              "add": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "drop": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "privileged": {
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "type": "string"
+                          },
+                          "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "type": "integer"
+                          },
+                          "runAsNonRoot": {
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "type": "integer"
+                          },
+                          "seLinuxOptions": {
+                            "properties": {
+                              "level": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "seccompProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "windowsOptions": {
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "startupProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stdin": {
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "type": "boolean"
+                      },
+                      "terminationMessagePath": {
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "type": "string"
+                      },
+                      "tty": {
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "items": {
+                          "properties": {
+                            "devicePath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            },
+                            "subPath": {
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "workingDir": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "dnsConfig": {
+                  "properties": {
+                    "nameservers": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "options": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "searches": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "dnsPolicy": {
+                  "type": "string"
+                },
+                "enableServiceLinks": {
+                  "type": "boolean"
+                },
+                "ephemeralContainers": {
+                  "items": {
+                    "properties": {
+                      "args": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "env": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secretKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "envFrom": {
+                        "items": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "type": "string"
+                      },
+                      "lifecycle": {
+                        "properties": {
+                          "postStart": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "sleep": {
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "preStop": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "sleep": {
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "livenessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ports": {
+                        "items": {
+                          "properties": {
+                            "containerPort": {
+                              "type": "integer"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "readinessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resizePolicy": {
+                        "items": {
+                          "properties": {
+                            "resourceName": {
+                              "type": "string"
+                            },
+                            "restartPolicy": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "restartPolicy": {
+                        "type": "string"
+                      },
+                      "securityContext": {
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                          },
+                          "appArmorProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "capabilities": {
+                            "properties": {
+                              "add": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "drop": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "privileged": {
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "type": "string"
+                          },
+                          "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "type": "integer"
+                          },
+                          "runAsNonRoot": {
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "type": "integer"
+                          },
+                          "seLinuxOptions": {
+                            "properties": {
+                              "level": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "seccompProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "windowsOptions": {
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "startupProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stdin": {
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "type": "boolean"
+                      },
+                      "targetContainerName": {
+                        "type": "string"
+                      },
+                      "terminationMessagePath": {
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "type": "string"
+                      },
+                      "tty": {
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "items": {
+                          "properties": {
+                            "devicePath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            },
+                            "subPath": {
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "workingDir": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "hostAliases": {
+                  "items": {
+                    "properties": {
+                      "hostnames": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "ip": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "hostIPC": {
+                  "type": "boolean"
+                },
+                "hostNetwork": {
+                  "type": "boolean"
+                },
+                "hostPID": {
+                  "type": "boolean"
+                },
+                "hostUsers": {
+                  "type": "boolean"
+                },
+                "hostname": {
+                  "type": "string"
+                },
+                "imagePullSecrets": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "initContainers": {
+                  "items": {
+                    "properties": {
+                      "args": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "command": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "env": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            },
+                            "valueFrom": {
+                              "properties": {
+                                "configMapKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secretKeyRef": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "envFrom": {
+                        "items": {
+                          "properties": {
+                            "configMapRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "prefix": {
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imagePullPolicy": {
+                        "type": "string"
+                      },
+                      "lifecycle": {
+                        "properties": {
+                          "postStart": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "sleep": {
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "preStop": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "sleep": {
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "livenessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ports": {
+                        "items": {
+                          "properties": {
+                            "containerPort": {
+                              "type": "integer"
+                            },
+                            "hostIP": {
+                              "type": "string"
+                            },
+                            "hostPort": {
+                              "type": "integer"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "protocol": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "readinessProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "resizePolicy": {
+                        "items": {
+                          "properties": {
+                            "resourceName": {
+                              "type": "string"
+                            },
+                            "restartPolicy": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "restartPolicy": {
+                        "type": "string"
+                      },
+                      "securityContext": {
+                        "properties": {
+                          "allowPrivilegeEscalation": {
+                            "type": "boolean"
+                          },
+                          "appArmorProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "capabilities": {
+                            "properties": {
+                              "add": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "drop": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "privileged": {
+                            "type": "boolean"
+                          },
+                          "procMount": {
+                            "type": "string"
+                          },
+                          "readOnlyRootFilesystem": {
+                            "type": "boolean"
+                          },
+                          "runAsGroup": {
+                            "type": "integer"
+                          },
+                          "runAsNonRoot": {
+                            "type": "boolean"
+                          },
+                          "runAsUser": {
+                            "type": "integer"
+                          },
+                          "seLinuxOptions": {
+                            "properties": {
+                              "level": {
+                                "type": "string"
+                              },
+                              "role": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "seccompProfile": {
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "windowsOptions": {
+                            "properties": {
+                              "gmsaCredentialSpec": {
+                                "type": "string"
+                              },
+                              "gmsaCredentialSpecName": {
+                                "type": "string"
+                              },
+                              "hostProcess": {
+                                "type": "boolean"
+                              },
+                              "runAsUserName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "startupProbe": {
+                        "properties": {
+                          "exec": {
+                            "properties": {
+                              "command": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "failureThreshold": {
+                            "type": "integer"
+                          },
+                          "grpc": {
+                            "properties": {
+                              "port": {
+                                "type": "integer"
+                              },
+                              "service": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "httpGet": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "httpHeaders": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "scheme": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "initialDelaySeconds": {
+                            "type": "integer"
+                          },
+                          "periodSeconds": {
+                            "type": "integer"
+                          },
+                          "successThreshold": {
+                            "type": "integer"
+                          },
+                          "tcpSocket": {
+                            "properties": {
+                              "host": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminationGracePeriodSeconds": {
+                            "type": "integer"
+                          },
+                          "timeoutSeconds": {
+                            "type": "integer"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stdin": {
+                        "type": "boolean"
+                      },
+                      "stdinOnce": {
+                        "type": "boolean"
+                      },
+                      "terminationMessagePath": {
+                        "type": "string"
+                      },
+                      "terminationMessagePolicy": {
+                        "type": "string"
+                      },
+                      "tty": {
+                        "type": "boolean"
+                      },
+                      "volumeDevices": {
+                        "items": {
+                          "properties": {
+                            "devicePath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "mountPropagation": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            },
+                            "subPath": {
+                              "type": "string"
+                            },
+                            "subPathExpr": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "workingDir": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "nodeName": {
+                  "type": "string"
+                },
+                "nodeSelector": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "os": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "overhead": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "x-kubernetes-int-or-string": true
+                  },
+                  "type": "object"
+                },
+                "preemptionPolicy": {
+                  "type": "string"
+                },
+                "priority": {
+                  "type": "integer"
+                },
+                "priorityClassName": {
+                  "type": "string"
+                },
+                "readinessGates": {
+                  "items": {
+                    "properties": {
+                      "conditionType": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "resourceClaims": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "resourceClaimName": {
+                        "type": "string"
+                      },
+                      "resourceClaimTemplateName": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "resources": {
+                  "properties": {
+                    "claims": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "request": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "limits": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    },
+                    "requests": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "restartPolicy": {
+                  "type": "string"
+                },
+                "runtimeClassName": {
+                  "type": "string"
+                },
+                "schedulerName": {
+                  "type": "string"
+                },
+                "schedulingGates": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "securityContext": {
+                  "properties": {
+                    "appArmorProfile": {
+                      "properties": {
+                        "localhostProfile": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "fsGroup": {
+                      "type": "integer"
+                    },
+                    "fsGroupChangePolicy": {
+                      "type": "string"
+                    },
+                    "runAsGroup": {
+                      "type": "integer"
+                    },
+                    "runAsNonRoot": {
+                      "type": "boolean"
+                    },
+                    "runAsUser": {
+                      "type": "integer"
+                    },
+                    "seLinuxChangePolicy": {
+                      "type": "string"
+                    },
+                    "seLinuxOptions": {
+                      "properties": {
+                        "level": {
+                          "type": "string"
+                        },
+                        "role": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "seccompProfile": {
+                      "properties": {
+                        "localhostProfile": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "supplementalGroups": {
+                      "items": {
+                        "type": "integer"
+                      },
+                      "type": "array"
+                    },
+                    "supplementalGroupsPolicy": {
+                      "type": "string"
+                    },
+                    "sysctls": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "windowsOptions": {
+                      "properties": {
+                        "gmsaCredentialSpec": {
+                          "type": "string"
+                        },
+                        "gmsaCredentialSpecName": {
+                          "type": "string"
+                        },
+                        "hostProcess": {
+                          "type": "boolean"
+                        },
+                        "runAsUserName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "serviceAccount": {
+                  "type": "string"
+                },
+                "serviceAccountName": {
+                  "type": "string"
+                },
+                "setHostnameAsFQDN": {
+                  "type": "boolean"
+                },
+                "shareProcessNamespace": {
+                  "type": "boolean"
+                },
+                "subdomain": {
+                  "type": "string"
+                },
+                "terminationGracePeriodSeconds": {
+                  "type": "integer"
+                },
+                "tolerations": {
+                  "items": {
+                    "properties": {
+                      "effect": {
+                        "type": "string"
+                      },
+                      "key": {
+                        "type": "string"
+                      },
+                      "operator": {
+                        "type": "string"
+                      },
+                      "tolerationSeconds": {
+                        "type": "integer"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "topologySpreadConstraints": {
+                  "items": {
+                    "properties": {
+                      "labelSelector": {
+                        "properties": {
+                          "matchExpressions": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "matchLabels": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "matchLabelKeys": {
+                        "items": {
+                          "type": "string"
+                        },
+                        "type": "array"
+                      },
+                      "maxSkew": {
+                        "type": "integer"
+                      },
+                      "minDomains": {
+                        "type": "integer"
+                      },
+                      "nodeAffinityPolicy": {
+                        "type": "string"
+                      },
+                      "nodeTaintsPolicy": {
+                        "type": "string"
+                      },
+                      "topologyKey": {
+                        "type": "string"
+                      },
+                      "whenUnsatisfiable": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "volumes": {
+                  "items": {
+                    "properties": {
+                      "awsElasticBlockStore": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "partition": {
+                            "type": "integer"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "azureDisk": {
+                        "properties": {
+                          "cachingMode": {
+                            "type": "string"
+                          },
+                          "diskName": {
+                            "type": "string"
+                          },
+                          "diskURI": {
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "azureFile": {
+                        "properties": {
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          },
+                          "shareName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cephfs": {
+                        "properties": {
+                          "monitors": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretFile": {
+                            "type": "string"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "user": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "cinder": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "volumeID": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "configMap": {
+                        "properties": {
+                          "defaultMode": {
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "csi": {
+                        "properties": {
+                          "driver": {
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "nodePublishSecretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "volumeAttributes": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "downwardAPI": {
+                        "properties": {
+                          "defaultMode": {
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "fieldRef": {
+                                  "properties": {
+                                    "apiVersion": {
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "mode": {
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "resourceFieldRef": {
+                                  "properties": {
+                                    "containerName": {
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ],
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "emptyDir": {
+                        "properties": {
+                          "medium": {
+                            "type": "string"
+                          },
+                          "sizeLimit": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "ephemeral": {
+                        "properties": {
+                          "volumeClaimTemplate": {
+                            "properties": {
+                              "metadata": {
+                                "properties": {
+                                  "annotations": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "creationTimestamp": {
+                                    "type": "string"
+                                  },
+                                  "deletionGracePeriodSeconds": {
+                                    "type": "integer"
+                                  },
+                                  "deletionTimestamp": {
+                                    "type": "string"
+                                  },
+                                  "finalizers": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "generateName": {
+                                    "type": "string"
+                                  },
+                                  "generation": {
+                                    "type": "integer"
+                                  },
+                                  "labels": {
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    },
+                                    "type": "object"
+                                  },
+                                  "managedFields": {
+                                    "items": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldsType": {
+                                          "type": "string"
+                                        },
+                                        "fieldsV1": {
+                                          "type": "object"
+                                        },
+                                        "manager": {
+                                          "type": "string"
+                                        },
+                                        "operation": {
+                                          "type": "string"
+                                        },
+                                        "subresource": {
+                                          "type": "string"
+                                        },
+                                        "time": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "type": "string"
+                                  },
+                                  "ownerReferences": {
+                                    "items": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "blockOwnerDeletion": {
+                                          "type": "boolean"
+                                        },
+                                        "controller": {
+                                          "type": "boolean"
+                                        },
+                                        "kind": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "uid": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "resourceVersion": {
+                                    "type": "string"
+                                  },
+                                  "selfLink": {
+                                    "type": "string"
+                                  },
+                                  "uid": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "spec": {
+                                "properties": {
+                                  "accessModes": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "dataSource": {
+                                    "properties": {
+                                      "apiGroup": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "dataSourceRef": {
+                                    "properties": {
+                                      "apiGroup": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "resources": {
+                                    "properties": {
+                                      "limits": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      },
+                                      "requests": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "selector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "storageClassName": {
+                                    "type": "string"
+                                  },
+                                  "volumeAttributesClassName": {
+                                    "type": "string"
+                                  },
+                                  "volumeMode": {
+                                    "type": "string"
+                                  },
+                                  "volumeName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "fc": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "lun": {
+                            "type": "integer"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "targetWWNs": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "wwids": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "flexVolume": {
+                        "properties": {
+                          "driver": {
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "options": {
+                            "additionalProperties": {
+                              "type": "string"
+                            },
+                            "type": "object"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "flocker": {
+                        "properties": {
+                          "datasetName": {
+                            "type": "string"
+                          },
+                          "datasetUUID": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "gcePersistentDisk": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "partition": {
+                            "type": "integer"
+                          },
+                          "pdName": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "gitRepo": {
+                        "properties": {
+                          "directory": {
+                            "type": "string"
+                          },
+                          "repository": {
+                            "type": "string"
+                          },
+                          "revision": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "glusterfs": {
+                        "properties": {
+                          "endpoints": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "hostPath": {
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "image": {
+                        "properties": {
+                          "pullPolicy": {
+                            "type": "string"
+                          },
+                          "reference": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "iscsi": {
+                        "properties": {
+                          "chapAuthDiscovery": {
+                            "type": "boolean"
+                          },
+                          "chapAuthSession": {
+                            "type": "boolean"
+                          },
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "initiatorName": {
+                            "type": "string"
+                          },
+                          "iqn": {
+                            "type": "string"
+                          },
+                          "iscsiInterface": {
+                            "type": "string"
+                          },
+                          "lun": {
+                            "type": "integer"
+                          },
+                          "portals": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "targetPortal": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "nfs": {
+                        "properties": {
+                          "path": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "server": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "persistentVolumeClaim": {
+                        "properties": {
+                          "claimName": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "photonPersistentDisk": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "pdID": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "portworxVolume": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "projected": {
+                        "properties": {
+                          "defaultMode": {
+                            "type": "integer"
+                          },
+                          "sources": {
+                            "items": {
+                              "properties": {
+                                "clusterTrustBundle": {
+                                  "properties": {
+                                    "labelSelector": {
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "matchLabels": {
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          },
+                                          "type": "object"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "signerName": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "configMap": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "downwardAPI": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "fieldRef": {
+                                            "properties": {
+                                              "apiVersion": {
+                                                "type": "string"
+                                              },
+                                              "fieldPath": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "mode": {
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "resourceFieldRef": {
+                                            "properties": {
+                                              "containerName": {
+                                                "type": "string"
+                                              },
+                                              "divisor": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  }
+                                                ],
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "resource": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "secret": {
+                                  "properties": {
+                                    "items": {
+                                      "items": {
+                                        "properties": {
+                                          "key": {
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "type": "integer"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "type": "array"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "serviceAccountToken": {
+                                  "properties": {
+                                    "audience": {
+                                      "type": "string"
+                                    },
+                                    "expirationSeconds": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "quobyte": {
+                        "properties": {
+                          "group": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "registry": {
+                            "type": "string"
+                          },
+                          "tenant": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "type": "string"
+                          },
+                          "volume": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "rbd": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "keyring": {
+                            "type": "string"
+                          },
+                          "monitors": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "pool": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "user": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "scaleIO": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "gateway": {
+                            "type": "string"
+                          },
+                          "protectionDomain": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "sslEnabled": {
+                            "type": "boolean"
+                          },
+                          "storageMode": {
+                            "type": "string"
+                          },
+                          "storagePool": {
+                            "type": "string"
+                          },
+                          "system": {
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "secret": {
+                        "properties": {
+                          "defaultMode": {
+                            "type": "integer"
+                          },
+                          "items": {
+                            "items": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "type": "integer"
+                                },
+                                "path": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "optional": {
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "storageos": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "volumeName": {
+                            "type": "string"
+                          },
+                          "volumeNamespace": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "vsphereVolume": {
+                        "properties": {
+                          "fsType": {
+                            "type": "string"
+                          },
+                          "storagePolicyID": {
+                            "type": "string"
+                          },
+                          "storagePolicyName": {
+                            "type": "string"
+                          },
+                          "volumePath": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "status": {
+              "properties": {
+                "conditions": {
+                  "items": {
+                    "properties": {
+                      "lastProbeTime": {
+                        "type": "string"
+                      },
+                      "lastTransitionTime": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "type": "string"
+                      },
+                      "observedGeneration": {
+                        "type": "integer"
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "containerStatuses": {
+                  "items": {
+                    "properties": {
+                      "allocatedResources": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
+                      "allocatedResourcesStatus": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "resources": {
+                              "items": {
+                                "properties": {
+                                  "health": {
+                                    "type": "string"
+                                  },
+                                  "resourceID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "containerID": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imageID": {
+                        "type": "string"
+                      },
+                      "lastState": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ready": {
+                        "type": "boolean"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "restartCount": {
+                        "type": "integer"
+                      },
+                      "started": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stopSignal": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "properties": {
+                          "linux": {
+                            "properties": {
+                              "gid": {
+                                "type": "integer"
+                              },
+                              "supplementalGroups": {
+                                "items": {
+                                  "type": "integer"
+                                },
+                                "type": "array"
+                              },
+                              "uid": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "ephemeralContainerStatuses": {
+                  "items": {
+                    "properties": {
+                      "allocatedResources": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
+                      "allocatedResourcesStatus": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "resources": {
+                              "items": {
+                                "properties": {
+                                  "health": {
+                                    "type": "string"
+                                  },
+                                  "resourceID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "containerID": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imageID": {
+                        "type": "string"
+                      },
+                      "lastState": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ready": {
+                        "type": "boolean"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "restartCount": {
+                        "type": "integer"
+                      },
+                      "started": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stopSignal": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "properties": {
+                          "linux": {
+                            "properties": {
+                              "gid": {
+                                "type": "integer"
+                              },
+                              "supplementalGroups": {
+                                "items": {
+                                  "type": "integer"
+                                },
+                                "type": "array"
+                              },
+                              "uid": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "hostIP": {
+                  "type": "string"
+                },
+                "hostIPs": {
+                  "items": {
+                    "properties": {
+                      "ip": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "initContainerStatuses": {
+                  "items": {
+                    "properties": {
+                      "allocatedResources": {
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "integer"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ],
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "type": "object"
+                      },
+                      "allocatedResourcesStatus": {
+                        "items": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "resources": {
+                              "items": {
+                                "properties": {
+                                  "health": {
+                                    "type": "string"
+                                  },
+                                  "resourceID": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      },
+                      "containerID": {
+                        "type": "string"
+                      },
+                      "image": {
+                        "type": "string"
+                      },
+                      "imageID": {
+                        "type": "string"
+                      },
+                      "lastState": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "ready": {
+                        "type": "boolean"
+                      },
+                      "resources": {
+                        "properties": {
+                          "claims": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "limits": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "requests": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "restartCount": {
+                        "type": "integer"
+                      },
+                      "started": {
+                        "type": "boolean"
+                      },
+                      "state": {
+                        "properties": {
+                          "running": {
+                            "properties": {
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "terminated": {
+                            "properties": {
+                              "containerID": {
+                                "type": "string"
+                              },
+                              "exitCode": {
+                                "type": "integer"
+                              },
+                              "finishedAt": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "signal": {
+                                "type": "integer"
+                              },
+                              "startedAt": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "waiting": {
+                            "properties": {
+                              "message": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "stopSignal": {
+                        "type": "string"
+                      },
+                      "user": {
+                        "properties": {
+                          "linux": {
+                            "properties": {
+                              "gid": {
+                                "type": "integer"
+                              },
+                              "supplementalGroups": {
+                                "items": {
+                                  "type": "integer"
+                                },
+                                "type": "array"
+                              },
+                              "uid": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "volumeMounts": {
+                        "items": {
+                          "properties": {
+                            "mountPath": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "type": "array"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "type": "string"
+                },
+                "nominatedNodeName": {
+                  "type": "string"
+                },
+                "observedGeneration": {
+                  "type": "integer"
+                },
+                "phase": {
+                  "type": "string"
+                },
+                "podIP": {
+                  "type": "string"
+                },
+                "podIPs": {
+                  "items": {
+                    "properties": {
+                      "ip": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "qosClass": {
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string"
+                },
+                "resize": {
+                  "type": "string"
+                },
+                "resourceClaimStatuses": {
+                  "items": {
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "resourceClaimName": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "startTime": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "restartNonce": {
+          "type": "integer"
+        },
+        "serviceAccount": {
+          "type": "string"
+        },
+        "taskManager": {
+          "properties": {
+            "podTemplate": {
+              "properties": {
+                "apiVersion": {
+                  "type": "string"
+                },
+                "kind": {
+                  "type": "string"
+                },
+                "metadata": {
+                  "properties": {
+                    "annotations": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "creationTimestamp": {
+                      "type": "string"
+                    },
+                    "deletionGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "deletionTimestamp": {
+                      "type": "string"
+                    },
+                    "finalizers": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "generateName": {
+                      "type": "string"
+                    },
+                    "generation": {
+                      "type": "integer"
+                    },
+                    "labels": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "managedFields": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "fieldsType": {
+                            "type": "string"
+                          },
+                          "fieldsV1": {
+                            "type": "object"
+                          },
+                          "manager": {
+                            "type": "string"
+                          },
+                          "operation": {
+                            "type": "string"
+                          },
+                          "subresource": {
+                            "type": "string"
+                          },
+                          "time": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    },
+                    "ownerReferences": {
+                      "items": {
+                        "properties": {
+                          "apiVersion": {
+                            "type": "string"
+                          },
+                          "blockOwnerDeletion": {
+                            "type": "boolean"
+                          },
+                          "controller": {
+                            "type": "boolean"
+                          },
+                          "kind": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "uid": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "resourceVersion": {
+                      "type": "string"
+                    },
+                    "selfLink": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "spec": {
+                  "properties": {
+                    "activeDeadlineSeconds": {
+                      "type": "integer"
+                    },
+                    "affinity": {
+                      "properties": {
+                        "nodeAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "preference": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "properties": {
+                                "nodeSelectorTerms": {
+                                  "items": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchFields": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "podAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "podAntiAffinity": {
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "properties": {
+                                      "labelSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "matchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "namespaceSelector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "namespaces": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "weight": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "items": {
+                                "properties": {
+                                  "labelSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "matchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "namespaceSelector": {
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "type": "array"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "matchLabels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "namespaces": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "topologyKey": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "automountServiceAccountToken": {
+                      "type": "boolean"
+                    },
+                    "containers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "dnsConfig": {
+                      "properties": {
+                        "nameservers": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "options": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "searches": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "dnsPolicy": {
+                      "type": "string"
+                    },
+                    "enableServiceLinks": {
+                      "type": "boolean"
+                    },
+                    "ephemeralContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "targetContainerName": {
+                            "type": "string"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "hostAliases": {
+                      "items": {
+                        "properties": {
+                          "hostnames": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "hostIPC": {
+                      "type": "boolean"
+                    },
+                    "hostNetwork": {
+                      "type": "boolean"
+                    },
+                    "hostPID": {
+                      "type": "boolean"
+                    },
+                    "hostUsers": {
+                      "type": "boolean"
+                    },
+                    "hostname": {
+                      "type": "string"
+                    },
+                    "imagePullSecrets": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "initContainers": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "command": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "env": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "type": "string"
+                                },
+                                "valueFrom": {
+                                  "properties": {
+                                    "configMapKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secretKeyRef": {
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "envFrom": {
+                            "items": {
+                              "properties": {
+                                "configMapRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "prefix": {
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imagePullPolicy": {
+                            "type": "string"
+                          },
+                          "lifecycle": {
+                            "properties": {
+                              "postStart": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "preStop": {
+                                "properties": {
+                                  "exec": {
+                                    "properties": {
+                                      "command": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "httpGet": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "httpHeaders": {
+                                        "items": {
+                                          "properties": {
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "scheme": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "sleep": {
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "tcpSocket": {
+                                    "properties": {
+                                      "host": {
+                                        "type": "string"
+                                      },
+                                      "port": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "string"
+                                          }
+                                        ],
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "stopSignal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "livenessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ports": {
+                            "items": {
+                              "properties": {
+                                "containerPort": {
+                                  "type": "integer"
+                                },
+                                "hostIP": {
+                                  "type": "string"
+                                },
+                                "hostPort": {
+                                  "type": "integer"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "protocol": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "readinessProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "resizePolicy": {
+                            "items": {
+                              "properties": {
+                                "resourceName": {
+                                  "type": "string"
+                                },
+                                "restartPolicy": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartPolicy": {
+                            "type": "string"
+                          },
+                          "securityContext": {
+                            "properties": {
+                              "allowPrivilegeEscalation": {
+                                "type": "boolean"
+                              },
+                              "appArmorProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "capabilities": {
+                                "properties": {
+                                  "add": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "drop": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "privileged": {
+                                "type": "boolean"
+                              },
+                              "procMount": {
+                                "type": "string"
+                              },
+                              "readOnlyRootFilesystem": {
+                                "type": "boolean"
+                              },
+                              "runAsGroup": {
+                                "type": "integer"
+                              },
+                              "runAsNonRoot": {
+                                "type": "boolean"
+                              },
+                              "runAsUser": {
+                                "type": "integer"
+                              },
+                              "seLinuxOptions": {
+                                "properties": {
+                                  "level": {
+                                    "type": "string"
+                                  },
+                                  "role": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "user": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "seccompProfile": {
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "windowsOptions": {
+                                "properties": {
+                                  "gmsaCredentialSpec": {
+                                    "type": "string"
+                                  },
+                                  "gmsaCredentialSpecName": {
+                                    "type": "string"
+                                  },
+                                  "hostProcess": {
+                                    "type": "boolean"
+                                  },
+                                  "runAsUserName": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "startupProbe": {
+                            "properties": {
+                              "exec": {
+                                "properties": {
+                                  "command": {
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "failureThreshold": {
+                                "type": "integer"
+                              },
+                              "grpc": {
+                                "properties": {
+                                  "port": {
+                                    "type": "integer"
+                                  },
+                                  "service": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "httpGet": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "httpHeaders": {
+                                    "items": {
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "type": "array"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "scheme": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "initialDelaySeconds": {
+                                "type": "integer"
+                              },
+                              "periodSeconds": {
+                                "type": "integer"
+                              },
+                              "successThreshold": {
+                                "type": "integer"
+                              },
+                              "tcpSocket": {
+                                "properties": {
+                                  "host": {
+                                    "type": "string"
+                                  },
+                                  "port": {
+                                    "anyOf": [
+                                      {
+                                        "type": "integer"
+                                      },
+                                      {
+                                        "type": "string"
+                                      }
+                                    ],
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminationGracePeriodSeconds": {
+                                "type": "integer"
+                              },
+                              "timeoutSeconds": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stdin": {
+                            "type": "boolean"
+                          },
+                          "stdinOnce": {
+                            "type": "boolean"
+                          },
+                          "terminationMessagePath": {
+                            "type": "string"
+                          },
+                          "terminationMessagePolicy": {
+                            "type": "string"
+                          },
+                          "tty": {
+                            "type": "boolean"
+                          },
+                          "volumeDevices": {
+                            "items": {
+                              "properties": {
+                                "devicePath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "mountPropagation": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
+                                "subPath": {
+                                  "type": "string"
+                                },
+                                "subPathExpr": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "workingDir": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "nodeName": {
+                      "type": "string"
+                    },
+                    "nodeSelector": {
+                      "additionalProperties": {
+                        "type": "string"
+                      },
+                      "type": "object"
+                    },
+                    "os": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "overhead": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "type": "integer"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ],
+                        "x-kubernetes-int-or-string": true
+                      },
+                      "type": "object"
+                    },
+                    "preemptionPolicy": {
+                      "type": "string"
+                    },
+                    "priority": {
+                      "type": "integer"
+                    },
+                    "priorityClassName": {
+                      "type": "string"
+                    },
+                    "readinessGates": {
+                      "items": {
+                        "properties": {
+                          "conditionType": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "resourceClaims": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "resourceClaimName": {
+                            "type": "string"
+                          },
+                          "resourceClaimTemplateName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "resources": {
+                      "properties": {
+                        "claims": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "request": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "limits": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        },
+                        "requests": {
+                          "additionalProperties": {
+                            "anyOf": [
+                              {
+                                "type": "integer"
+                              },
+                              {
+                                "type": "string"
+                              }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "restartPolicy": {
+                      "type": "string"
+                    },
+                    "runtimeClassName": {
+                      "type": "string"
+                    },
+                    "schedulerName": {
+                      "type": "string"
+                    },
+                    "schedulingGates": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "securityContext": {
+                      "properties": {
+                        "appArmorProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "fsGroup": {
+                          "type": "integer"
+                        },
+                        "fsGroupChangePolicy": {
+                          "type": "string"
+                        },
+                        "runAsGroup": {
+                          "type": "integer"
+                        },
+                        "runAsNonRoot": {
+                          "type": "boolean"
+                        },
+                        "runAsUser": {
+                          "type": "integer"
+                        },
+                        "seLinuxChangePolicy": {
+                          "type": "string"
+                        },
+                        "seLinuxOptions": {
+                          "properties": {
+                            "level": {
+                              "type": "string"
+                            },
+                            "role": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            },
+                            "user": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "seccompProfile": {
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        },
+                        "supplementalGroups": {
+                          "items": {
+                            "type": "integer"
+                          },
+                          "type": "array"
+                        },
+                        "supplementalGroupsPolicy": {
+                          "type": "string"
+                        },
+                        "sysctls": {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "type": "array"
+                        },
+                        "windowsOptions": {
+                          "properties": {
+                            "gmsaCredentialSpec": {
+                              "type": "string"
+                            },
+                            "gmsaCredentialSpecName": {
+                              "type": "string"
+                            },
+                            "hostProcess": {
+                              "type": "boolean"
+                            },
+                            "runAsUserName": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object",
+                          "additionalProperties": false
+                        }
+                      },
+                      "type": "object",
+                      "additionalProperties": false
+                    },
+                    "serviceAccount": {
+                      "type": "string"
+                    },
+                    "serviceAccountName": {
+                      "type": "string"
+                    },
+                    "setHostnameAsFQDN": {
+                      "type": "boolean"
+                    },
+                    "shareProcessNamespace": {
+                      "type": "boolean"
+                    },
+                    "subdomain": {
+                      "type": "string"
+                    },
+                    "terminationGracePeriodSeconds": {
+                      "type": "integer"
+                    },
+                    "tolerations": {
+                      "items": {
+                        "properties": {
+                          "effect": {
+                            "type": "string"
+                          },
+                          "key": {
+                            "type": "string"
+                          },
+                          "operator": {
+                            "type": "string"
+                          },
+                          "tolerationSeconds": {
+                            "type": "integer"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "topologySpreadConstraints": {
+                      "items": {
+                        "properties": {
+                          "labelSelector": {
+                            "properties": {
+                              "matchExpressions": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "matchLabels": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "matchLabelKeys": {
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "maxSkew": {
+                            "type": "integer"
+                          },
+                          "minDomains": {
+                            "type": "integer"
+                          },
+                          "nodeAffinityPolicy": {
+                            "type": "string"
+                          },
+                          "nodeTaintsPolicy": {
+                            "type": "string"
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          },
+                          "whenUnsatisfiable": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "volumes": {
+                      "items": {
+                        "properties": {
+                          "awsElasticBlockStore": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azureDisk": {
+                            "properties": {
+                              "cachingMode": {
+                                "type": "string"
+                              },
+                              "diskName": {
+                                "type": "string"
+                              },
+                              "diskURI": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "azureFile": {
+                            "properties": {
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              },
+                              "shareName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "cephfs": {
+                            "properties": {
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretFile": {
+                                "type": "string"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "cinder": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "configMap": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "csi": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "nodePublishSecretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeAttributes": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "downwardAPI": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "fieldRef": {
+                                      "properties": {
+                                        "apiVersion": {
+                                          "type": "string"
+                                        },
+                                        "fieldPath": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "resourceFieldRef": {
+                                      "properties": {
+                                        "containerName": {
+                                          "type": "string"
+                                        },
+                                        "divisor": {
+                                          "anyOf": [
+                                            {
+                                              "type": "integer"
+                                            },
+                                            {
+                                              "type": "string"
+                                            }
+                                          ],
+                                          "x-kubernetes-int-or-string": true
+                                        },
+                                        "resource": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "emptyDir": {
+                            "properties": {
+                              "medium": {
+                                "type": "string"
+                              },
+                              "sizeLimit": {
+                                "anyOf": [
+                                  {
+                                    "type": "integer"
+                                  },
+                                  {
+                                    "type": "string"
+                                  }
+                                ],
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "ephemeral": {
+                            "properties": {
+                              "volumeClaimTemplate": {
+                                "properties": {
+                                  "metadata": {
+                                    "properties": {
+                                      "annotations": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "creationTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "deletionGracePeriodSeconds": {
+                                        "type": "integer"
+                                      },
+                                      "deletionTimestamp": {
+                                        "type": "string"
+                                      },
+                                      "finalizers": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "generateName": {
+                                        "type": "string"
+                                      },
+                                      "generation": {
+                                        "type": "integer"
+                                      },
+                                      "labels": {
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        },
+                                        "type": "object"
+                                      },
+                                      "managedFields": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "fieldsType": {
+                                              "type": "string"
+                                            },
+                                            "fieldsV1": {
+                                              "type": "object"
+                                            },
+                                            "manager": {
+                                              "type": "string"
+                                            },
+                                            "operation": {
+                                              "type": "string"
+                                            },
+                                            "subresource": {
+                                              "type": "string"
+                                            },
+                                            "time": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "type": "string"
+                                      },
+                                      "ownerReferences": {
+                                        "items": {
+                                          "properties": {
+                                            "apiVersion": {
+                                              "type": "string"
+                                            },
+                                            "blockOwnerDeletion": {
+                                              "type": "boolean"
+                                            },
+                                            "controller": {
+                                              "type": "boolean"
+                                            },
+                                            "kind": {
+                                              "type": "string"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "uid": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "type": "array"
+                                      },
+                                      "resourceVersion": {
+                                        "type": "string"
+                                      },
+                                      "selfLink": {
+                                        "type": "string"
+                                      },
+                                      "uid": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "spec": {
+                                    "properties": {
+                                      "accessModes": {
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "type": "array"
+                                      },
+                                      "dataSource": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "dataSourceRef": {
+                                        "properties": {
+                                          "apiGroup": {
+                                            "type": "string"
+                                          },
+                                          "kind": {
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "namespace": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "resources": {
+                                        "properties": {
+                                          "limits": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          },
+                                          "requests": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "integer"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                }
+                                              ],
+                                              "x-kubernetes-int-or-string": true
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "selector": {
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "items": {
+                                              "properties": {
+                                                "key": {
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              },
+                                              "type": "object",
+                                              "additionalProperties": false
+                                            },
+                                            "type": "array"
+                                          },
+                                          "matchLabels": {
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            },
+                                            "type": "object"
+                                          }
+                                        },
+                                        "type": "object",
+                                        "additionalProperties": false
+                                      },
+                                      "storageClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeAttributesClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeMode": {
+                                        "type": "string"
+                                      },
+                                      "volumeName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "fc": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "targetWWNs": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "wwids": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "flexVolume": {
+                            "properties": {
+                              "driver": {
+                                "type": "string"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "options": {
+                                "additionalProperties": {
+                                  "type": "string"
+                                },
+                                "type": "object"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "flocker": {
+                            "properties": {
+                              "datasetName": {
+                                "type": "string"
+                              },
+                              "datasetUUID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "gcePersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "partition": {
+                                "type": "integer"
+                              },
+                              "pdName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "gitRepo": {
+                            "properties": {
+                              "directory": {
+                                "type": "string"
+                              },
+                              "repository": {
+                                "type": "string"
+                              },
+                              "revision": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "glusterfs": {
+                            "properties": {
+                              "endpoints": {
+                                "type": "string"
+                              },
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "hostPath": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "image": {
+                            "properties": {
+                              "pullPolicy": {
+                                "type": "string"
+                              },
+                              "reference": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "iscsi": {
+                            "properties": {
+                              "chapAuthDiscovery": {
+                                "type": "boolean"
+                              },
+                              "chapAuthSession": {
+                                "type": "boolean"
+                              },
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "initiatorName": {
+                                "type": "string"
+                              },
+                              "iqn": {
+                                "type": "string"
+                              },
+                              "iscsiInterface": {
+                                "type": "string"
+                              },
+                              "lun": {
+                                "type": "integer"
+                              },
+                              "portals": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "targetPortal": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "nfs": {
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "server": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "persistentVolumeClaim": {
+                            "properties": {
+                              "claimName": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "photonPersistentDisk": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "pdID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "portworxVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "volumeID": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "projected": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "sources": {
+                                "items": {
+                                  "properties": {
+                                    "clusterTrustBundle": {
+                                      "properties": {
+                                        "labelSelector": {
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "type": "array"
+                                            },
+                                            "matchLabels": {
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              },
+                                              "type": "object"
+                                            }
+                                          },
+                                          "type": "object",
+                                          "additionalProperties": false
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "signerName": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "configMap": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "downwardAPI": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "fieldRef": {
+                                                "properties": {
+                                                  "apiVersion": {
+                                                    "type": "string"
+                                                  },
+                                                  "fieldPath": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "resourceFieldRef": {
+                                                "properties": {
+                                                  "containerName": {
+                                                    "type": "string"
+                                                  },
+                                                  "divisor": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "integer"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      }
+                                                    ],
+                                                    "x-kubernetes-int-or-string": true
+                                                  },
+                                                  "resource": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object",
+                                                "additionalProperties": false
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "secret": {
+                                      "properties": {
+                                        "items": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "mode": {
+                                                "type": "integer"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object",
+                                            "additionalProperties": false
+                                          },
+                                          "type": "array"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    },
+                                    "serviceAccountToken": {
+                                      "properties": {
+                                        "audience": {
+                                          "type": "string"
+                                        },
+                                        "expirationSeconds": {
+                                          "type": "integer"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object",
+                                      "additionalProperties": false
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "quobyte": {
+                            "properties": {
+                              "group": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "registry": {
+                                "type": "string"
+                              },
+                              "tenant": {
+                                "type": "string"
+                              },
+                              "user": {
+                                "type": "string"
+                              },
+                              "volume": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "rbd": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "image": {
+                                "type": "string"
+                              },
+                              "keyring": {
+                                "type": "string"
+                              },
+                              "monitors": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "pool": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "user": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "scaleIO": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "gateway": {
+                                "type": "string"
+                              },
+                              "protectionDomain": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "sslEnabled": {
+                                "type": "boolean"
+                              },
+                              "storageMode": {
+                                "type": "string"
+                              },
+                              "storagePool": {
+                                "type": "string"
+                              },
+                              "system": {
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "secret": {
+                            "properties": {
+                              "defaultMode": {
+                                "type": "integer"
+                              },
+                              "items": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "mode": {
+                                      "type": "integer"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "optional": {
+                                "type": "boolean"
+                              },
+                              "secretName": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "storageos": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "secretRef": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "volumeName": {
+                                "type": "string"
+                              },
+                              "volumeNamespace": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "vsphereVolume": {
+                            "properties": {
+                              "fsType": {
+                                "type": "string"
+                              },
+                              "storagePolicyID": {
+                                "type": "string"
+                              },
+                              "storagePolicyName": {
+                                "type": "string"
+                              },
+                              "volumePath": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "status": {
+                  "properties": {
+                    "conditions": {
+                      "items": {
+                        "properties": {
+                          "lastProbeTime": {
+                            "type": "string"
+                          },
+                          "lastTransitionTime": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "observedGeneration": {
+                            "type": "integer"
+                          },
+                          "reason": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "containerStatuses": {
+                      "items": {
+                        "properties": {
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "allocatedResourcesStatus": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "resources": {
+                                  "items": {
+                                    "properties": {
+                                      "health": {
+                                        "type": "string"
+                                      },
+                                      "resourceID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "containerID": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imageID": {
+                            "type": "string"
+                          },
+                          "lastState": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ready": {
+                            "type": "boolean"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartCount": {
+                            "type": "integer"
+                          },
+                          "started": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "properties": {
+                              "linux": {
+                                "properties": {
+                                  "gid": {
+                                    "type": "integer"
+                                  },
+                                  "supplementalGroups": {
+                                    "items": {
+                                      "type": "integer"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "uid": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "ephemeralContainerStatuses": {
+                      "items": {
+                        "properties": {
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "allocatedResourcesStatus": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "resources": {
+                                  "items": {
+                                    "properties": {
+                                      "health": {
+                                        "type": "string"
+                                      },
+                                      "resourceID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "containerID": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imageID": {
+                            "type": "string"
+                          },
+                          "lastState": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ready": {
+                            "type": "boolean"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartCount": {
+                            "type": "integer"
+                          },
+                          "started": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "properties": {
+                              "linux": {
+                                "properties": {
+                                  "gid": {
+                                    "type": "integer"
+                                  },
+                                  "supplementalGroups": {
+                                    "items": {
+                                      "type": "integer"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "uid": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "hostIP": {
+                      "type": "string"
+                    },
+                    "hostIPs": {
+                      "items": {
+                        "properties": {
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "initContainerStatuses": {
+                      "items": {
+                        "properties": {
+                          "allocatedResources": {
+                            "additionalProperties": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ],
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "type": "object"
+                          },
+                          "allocatedResourcesStatus": {
+                            "items": {
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "resources": {
+                                  "items": {
+                                    "properties": {
+                                      "health": {
+                                        "type": "string"
+                                      },
+                                      "resourceID": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object",
+                                    "additionalProperties": false
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          },
+                          "containerID": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": "string"
+                          },
+                          "imageID": {
+                            "type": "string"
+                          },
+                          "lastState": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "ready": {
+                            "type": "boolean"
+                          },
+                          "resources": {
+                            "properties": {
+                              "claims": {
+                                "items": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object",
+                                  "additionalProperties": false
+                                },
+                                "type": "array"
+                              },
+                              "limits": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              },
+                              "requests": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "type": "integer"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "type": "object"
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "restartCount": {
+                            "type": "integer"
+                          },
+                          "started": {
+                            "type": "boolean"
+                          },
+                          "state": {
+                            "properties": {
+                              "running": {
+                                "properties": {
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "terminated": {
+                                "properties": {
+                                  "containerID": {
+                                    "type": "string"
+                                  },
+                                  "exitCode": {
+                                    "type": "integer"
+                                  },
+                                  "finishedAt": {
+                                    "type": "string"
+                                  },
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  },
+                                  "signal": {
+                                    "type": "integer"
+                                  },
+                                  "startedAt": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              },
+                              "waiting": {
+                                "properties": {
+                                  "message": {
+                                    "type": "string"
+                                  },
+                                  "reason": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "stopSignal": {
+                            "type": "string"
+                          },
+                          "user": {
+                            "properties": {
+                              "linux": {
+                                "properties": {
+                                  "gid": {
+                                    "type": "integer"
+                                  },
+                                  "supplementalGroups": {
+                                    "items": {
+                                      "type": "integer"
+                                    },
+                                    "type": "array"
+                                  },
+                                  "uid": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "type": "object",
+                                "additionalProperties": false
+                              }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                          },
+                          "volumeMounts": {
+                            "items": {
+                              "properties": {
+                                "mountPath": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "readOnly": {
+                                  "type": "boolean"
+                                },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object",
+                              "additionalProperties": false
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "nominatedNodeName": {
+                      "type": "string"
+                    },
+                    "observedGeneration": {
+                      "type": "integer"
+                    },
+                    "phase": {
+                      "type": "string"
+                    },
+                    "podIP": {
+                      "type": "string"
+                    },
+                    "podIPs": {
+                      "items": {
+                        "properties": {
+                          "ip": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "qosClass": {
+                      "type": "string"
+                    },
+                    "reason": {
+                      "type": "string"
+                    },
+                    "resize": {
+                      "type": "string"
+                    },
+                    "resourceClaimStatuses": {
+                      "items": {
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "resourceClaimName": {
+                            "type": "string"
+                          }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                      },
+                      "type": "array"
+                    },
+                    "startTime": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "replicas": {
+              "type": "integer"
+            },
+            "resource": {
+              "properties": {
+                "cpu": {
+                  "type": "number"
+                },
+                "ephemeralStorage": {
+                  "type": "string"
+                },
+                "memory": {
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "clusterInfo": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "conditions": {
+          "items": {
+            "properties": {
+              "lastTransitionTime": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              },
+              "observedGeneration": {
+                "type": "integer"
+              },
+              "reason": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "error": {
+          "type": "string"
+        },
+        "jobManagerDeploymentStatus": {
+          "enum": [
+            "DEPLOYED_NOT_READY",
+            "DEPLOYING",
+            "ERROR",
+            "MISSING",
+            "READY"
+          ],
+          "type": "string"
+        },
+        "jobStatus": {
+          "properties": {
+            "checkpointInfo": {
+              "properties": {
+                "formatType": {
+                  "enum": [
+                    "FULL",
+                    "INCREMENTAL",
+                    "UNKNOWN"
+                  ],
+                  "type": "string"
+                },
+                "lastCheckpoint": {
+                  "properties": {
+                    "formatType": {
+                      "enum": [
+                        "FULL",
+                        "INCREMENTAL",
+                        "UNKNOWN"
+                      ],
+                      "type": "string"
+                    },
+                    "timeStamp": {
+                      "type": "integer"
+                    },
+                    "triggerNonce": {
+                      "type": "integer"
+                    },
+                    "triggerType": {
+                      "enum": [
+                        "MANUAL",
+                        "PERIODIC",
+                        "UNKNOWN",
+                        "UPGRADE"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "lastPeriodicCheckpointTimestamp": {
+                  "type": "integer"
+                },
+                "triggerId": {
+                  "type": "string"
+                },
+                "triggerTimestamp": {
+                  "type": "integer"
+                },
+                "triggerType": {
+                  "enum": [
+                    "MANUAL",
+                    "PERIODIC",
+                    "UNKNOWN",
+                    "UPGRADE"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "jobId": {
+              "type": "string"
+            },
+            "jobName": {
+              "type": "string"
+            },
+            "savepointInfo": {
+              "properties": {
+                "formatType": {
+                  "enum": [
+                    "CANONICAL",
+                    "NATIVE",
+                    "UNKNOWN"
+                  ],
+                  "type": "string"
+                },
+                "lastPeriodicSavepointTimestamp": {
+                  "type": "integer"
+                },
+                "lastSavepoint": {
+                  "properties": {
+                    "formatType": {
+                      "enum": [
+                        "CANONICAL",
+                        "NATIVE",
+                        "UNKNOWN"
+                      ],
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    },
+                    "timeStamp": {
+                      "type": "integer"
+                    },
+                    "triggerNonce": {
+                      "type": "integer"
+                    },
+                    "triggerType": {
+                      "enum": [
+                        "MANUAL",
+                        "PERIODIC",
+                        "UNKNOWN",
+                        "UPGRADE"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "savepointHistory": {
+                  "items": {
+                    "properties": {
+                      "formatType": {
+                        "enum": [
+                          "CANONICAL",
+                          "NATIVE",
+                          "UNKNOWN"
+                        ],
+                        "type": "string"
+                      },
+                      "location": {
+                        "type": "string"
+                      },
+                      "timeStamp": {
+                        "type": "integer"
+                      },
+                      "triggerNonce": {
+                        "type": "integer"
+                      },
+                      "triggerType": {
+                        "enum": [
+                          "MANUAL",
+                          "PERIODIC",
+                          "UNKNOWN",
+                          "UPGRADE"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "triggerId": {
+                  "type": "string"
+                },
+                "triggerTimestamp": {
+                  "type": "integer"
+                },
+                "triggerType": {
+                  "enum": [
+                    "MANUAL",
+                    "PERIODIC",
+                    "UNKNOWN",
+                    "UPGRADE"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "startTime": {
+              "type": "string"
+            },
+            "state": {
+              "enum": [
+                "CANCELED",
+                "CANCELLING",
+                "CREATED",
+                "FAILED",
+                "FAILING",
+                "FINISHED",
+                "INITIALIZING",
+                "RECONCILING",
+                "RESTARTING",
+                "RUNNING",
+                "SUSPENDED"
+              ],
+              "type": "string"
+            },
+            "updateTime": {
+              "type": "string"
+            },
+            "upgradeSavepointPath": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "lifecycleState": {
+          "enum": [
+            "CREATED",
+            "DELETED",
+            "DELETING",
+            "DEPLOYED",
+            "FAILED",
+            "ROLLED_BACK",
+            "ROLLING_BACK",
+            "STABLE",
+            "SUSPENDED",
+            "UPGRADING"
+          ],
+          "type": "string"
+        },
+        "observedGeneration": {
+          "type": "integer"
+        },
+        "reconciliationStatus": {
+          "properties": {
+            "lastReconciledSpec": {
+              "type": "string"
+            },
+            "lastStableSpec": {
+              "type": "string"
+            },
+            "reconciliationTimestamp": {
+              "type": "integer"
+            },
+            "state": {
+              "enum": [
+                "DEPLOYED",
+                "ROLLED_BACK",
+                "ROLLING_BACK",
+                "UPGRADING"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "taskManager": {
+          "properties": {
+            "labelSelector": {
+              "type": "string"
+            },
+            "replicas": {
+              "type": "integer"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/master-standalone/flinksessionjob_v1beta1.json
+++ b/master-standalone/flinksessionjob_v1beta1.json
@@ -1,0 +1,322 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "deploymentName": {
+          "type": "string"
+        },
+        "flinkConfiguration": {
+          "x-kubernetes-preserve-unknown-fields": true
+        },
+        "job": {
+          "properties": {
+            "allowNonRestoredState": {
+              "type": "boolean"
+            },
+            "args": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "autoscalerResetNonce": {
+              "type": "integer"
+            },
+            "checkpointTriggerNonce": {
+              "type": "integer"
+            },
+            "entryClass": {
+              "type": "string"
+            },
+            "initialSavepointPath": {
+              "type": "string"
+            },
+            "jarURI": {
+              "type": "string"
+            },
+            "parallelism": {
+              "type": "integer"
+            },
+            "savepointRedeployNonce": {
+              "type": "integer"
+            },
+            "savepointTriggerNonce": {
+              "type": "integer"
+            },
+            "state": {
+              "enum": [
+                "running",
+                "suspended"
+              ],
+              "type": "string"
+            },
+            "upgradeMode": {
+              "enum": [
+                "last-state",
+                "savepoint",
+                "stateless"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "restartNonce": {
+          "type": "integer"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "jobStatus": {
+          "properties": {
+            "checkpointInfo": {
+              "properties": {
+                "formatType": {
+                  "enum": [
+                    "FULL",
+                    "INCREMENTAL",
+                    "UNKNOWN"
+                  ],
+                  "type": "string"
+                },
+                "lastCheckpoint": {
+                  "properties": {
+                    "formatType": {
+                      "enum": [
+                        "FULL",
+                        "INCREMENTAL",
+                        "UNKNOWN"
+                      ],
+                      "type": "string"
+                    },
+                    "timeStamp": {
+                      "type": "integer"
+                    },
+                    "triggerNonce": {
+                      "type": "integer"
+                    },
+                    "triggerType": {
+                      "enum": [
+                        "MANUAL",
+                        "PERIODIC",
+                        "UNKNOWN",
+                        "UPGRADE"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "lastPeriodicCheckpointTimestamp": {
+                  "type": "integer"
+                },
+                "triggerId": {
+                  "type": "string"
+                },
+                "triggerTimestamp": {
+                  "type": "integer"
+                },
+                "triggerType": {
+                  "enum": [
+                    "MANUAL",
+                    "PERIODIC",
+                    "UNKNOWN",
+                    "UPGRADE"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "jobId": {
+              "type": "string"
+            },
+            "jobName": {
+              "type": "string"
+            },
+            "savepointInfo": {
+              "properties": {
+                "formatType": {
+                  "enum": [
+                    "CANONICAL",
+                    "NATIVE",
+                    "UNKNOWN"
+                  ],
+                  "type": "string"
+                },
+                "lastPeriodicSavepointTimestamp": {
+                  "type": "integer"
+                },
+                "lastSavepoint": {
+                  "properties": {
+                    "formatType": {
+                      "enum": [
+                        "CANONICAL",
+                        "NATIVE",
+                        "UNKNOWN"
+                      ],
+                      "type": "string"
+                    },
+                    "location": {
+                      "type": "string"
+                    },
+                    "timeStamp": {
+                      "type": "integer"
+                    },
+                    "triggerNonce": {
+                      "type": "integer"
+                    },
+                    "triggerType": {
+                      "enum": [
+                        "MANUAL",
+                        "PERIODIC",
+                        "UNKNOWN",
+                        "UPGRADE"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "type": "object",
+                  "additionalProperties": false
+                },
+                "savepointHistory": {
+                  "items": {
+                    "properties": {
+                      "formatType": {
+                        "enum": [
+                          "CANONICAL",
+                          "NATIVE",
+                          "UNKNOWN"
+                        ],
+                        "type": "string"
+                      },
+                      "location": {
+                        "type": "string"
+                      },
+                      "timeStamp": {
+                        "type": "integer"
+                      },
+                      "triggerNonce": {
+                        "type": "integer"
+                      },
+                      "triggerType": {
+                        "enum": [
+                          "MANUAL",
+                          "PERIODIC",
+                          "UNKNOWN",
+                          "UPGRADE"
+                        ],
+                        "type": "string"
+                      }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                  },
+                  "type": "array"
+                },
+                "triggerId": {
+                  "type": "string"
+                },
+                "triggerTimestamp": {
+                  "type": "integer"
+                },
+                "triggerType": {
+                  "enum": [
+                    "MANUAL",
+                    "PERIODIC",
+                    "UNKNOWN",
+                    "UPGRADE"
+                  ],
+                  "type": "string"
+                }
+              },
+              "type": "object",
+              "additionalProperties": false
+            },
+            "startTime": {
+              "type": "string"
+            },
+            "state": {
+              "enum": [
+                "CANCELED",
+                "CANCELLING",
+                "CREATED",
+                "FAILED",
+                "FAILING",
+                "FINISHED",
+                "INITIALIZING",
+                "RECONCILING",
+                "RESTARTING",
+                "RUNNING",
+                "SUSPENDED"
+              ],
+              "type": "string"
+            },
+            "updateTime": {
+              "type": "string"
+            },
+            "upgradeSavepointPath": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "lifecycleState": {
+          "enum": [
+            "CREATED",
+            "DELETED",
+            "DELETING",
+            "DEPLOYED",
+            "FAILED",
+            "ROLLED_BACK",
+            "ROLLING_BACK",
+            "STABLE",
+            "SUSPENDED",
+            "UPGRADING"
+          ],
+          "type": "string"
+        },
+        "observedGeneration": {
+          "type": "integer"
+        },
+        "reconciliationStatus": {
+          "properties": {
+            "lastReconciledSpec": {
+              "type": "string"
+            },
+            "lastStableSpec": {
+              "type": "string"
+            },
+            "reconciliationTimestamp": {
+              "type": "integer"
+            },
+            "state": {
+              "enum": [
+                "DEPLOYED",
+                "ROLLED_BACK",
+                "ROLLING_BACK",
+                "UPGRADING"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/master-standalone/flinkstatesnapshot_v1beta1.json
+++ b/master-standalone/flinkstatesnapshot_v1beta1.json
@@ -1,0 +1,90 @@
+{
+  "properties": {
+    "spec": {
+      "properties": {
+        "backoffLimit": {
+          "type": "integer"
+        },
+        "checkpoint": {
+          "type": "object"
+        },
+        "jobReference": {
+          "properties": {
+            "kind": {
+              "enum": [
+                "FlinkDeployment",
+                "FlinkSessionJob"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        },
+        "savepoint": {
+          "properties": {
+            "alreadyExists": {
+              "type": "boolean"
+            },
+            "disposeOnDelete": {
+              "type": "boolean"
+            },
+            "formatType": {
+              "enum": [
+                "CANONICAL",
+                "NATIVE",
+                "UNKNOWN"
+              ],
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "failures": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string"
+        },
+        "resultTimestamp": {
+          "type": "string"
+        },
+        "state": {
+          "enum": [
+            "ABANDONED",
+            "COMPLETED",
+            "FAILED",
+            "IN_PROGRESS",
+            "TRIGGER_PENDING"
+          ],
+          "type": "string"
+        },
+        "triggerId": {
+          "type": "string"
+        },
+        "triggerTimestamp": {
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Add Flink crds so that we can run schema validation across multiple SRE owned repos.

Files added:
```
git diff --name-only master
master-standalone-strict/flinkbluegreendeployment_v1beta1.json
master-standalone-strict/flinkdeployment_v1beta1.json
master-standalone-strict/flinksessionjob_v1beta1.json
master-standalone-strict/flinkstatesnapshot_v1beta1.json
master-standalone/flinkbluegreendeployment_v1beta1.json
master-standalone/flinkdeployment_v1beta1.json
master-standalone/flinksessionjob_v1beta1.json
master-standalone/flinkstatesnapshot_v1beta1.json
```

Commands ran:
```
./scripts/openapi2jsonschema.py ../kube-resources/crds/flink-operator/flinkbluegreendeployments.flink.apache.org-v1.yaml
./scripts/openapi2jsonschema.py ../kube-resources/crds/flink-operator/flinkdeployments.flink.apache.org-v1.yaml
./scripts/openapi2jsonschema.py ../kube-resources/crds/flink-operator/flinkstatesnapshots.flink.apache.org-v1.yaml
./scripts/openapi2jsonschema.py ../kube-resources/crds/flink-operator/flinksessionjobs.flink.apache.org-v1.yaml
```