### PR TITLE
SRE-17602: Add missing CRD schemas

### DIFF
--- a/master-standalone-strict/argoworkflowresourcev2claim-deployment-v1alpha1.json
+++ b/master-standalone-strict/argoworkflowresourcev2claim-deployment-v1alpha1.json
@@ -1,0 +1,61 @@
+{
+  "type": "object",
+  "properties": {
+    "spec": {
+      "type": "object",
+      "properties": {
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "serviceAccountNamespace": {
+              "type": "string",
+              "description": "Kubernetes namespace of the service account."
+            },
+            "bucketArn": {
+              "type": "string",
+              "description": "ARN of the S3 bucket for storing artifacts."
+            },
+            "oidcProvider": {
+              "type": "object",
+              "properties": {
+                "arn": {
+                  "type": "string",
+                  "description": "ARN of the OIDC provider."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Name of the OIDC provider."
+                }
+              },
+              "required": [
+                "arn",
+                "name"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "serviceAccountNamespace",
+            "bucketArn",
+            "oidcProvider"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "parameters"
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "type": "object",
+      "properties": {
+        "roleArn": {
+          "type": "string",
+          "description": "ARN of the created IAM Role."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/master-standalone-strict/function-pkg-v1.json
+++ b/master-standalone-strict/function-pkg-v1.json
@@ -1,0 +1,183 @@
+{
+  "description": "A Function installs an OCI compatible Crossplane package, extending\nCrossplane with support for a new kind of composition function.\n\n\nRead the Crossplane documentation for\n[more information about Functions](https://docs.crossplane.io/latest/concepts/composition-functions).",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "FunctionSpec specifies the configuration of a Function.",
+      "properties": {
+        "commonLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/",
+          "type": "object"
+        },
+        "controllerConfigRef": {
+          "description": "ControllerConfigRef references a ControllerConfig resource that will be\nused to configure the packaged controller Deployment.\nDeprecated: Use RuntimeConfigReference instead.",
+          "properties": {
+            "name": {
+              "description": "Name of the ControllerConfig.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ignoreCrossplaneConstraints": {
+          "default": false,
+          "description": "IgnoreCrossplaneConstraints indicates to the package manager whether to\nhonor Crossplane version constrains specified by the package.\nDefault is false.",
+          "type": "boolean"
+        },
+        "package": {
+          "description": "Package is the name of the package that is being requested.",
+          "type": "string"
+        },
+        "packagePullPolicy": {
+          "default": "IfNotPresent",
+          "description": "PackagePullPolicy defines the pull policy for the package.\nDefault is IfNotPresent.",
+          "type": "string"
+        },
+        "packagePullSecrets": {
+          "description": "PackagePullSecrets are named secrets in the same namespace that can be used\nto fetch packages from private registries.",
+          "items": {
+            "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+            "properties": {
+              "name": {
+                "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "revisionActivationPolicy": {
+          "default": "Automatic",
+          "description": "RevisionActivationPolicy specifies how the package controller should\nupdate from one revision to the next. Options are Automatic or Manual.\nDefault is Automatic.",
+          "type": "string"
+        },
+        "revisionHistoryLimit": {
+          "default": 1,
+          "description": "RevisionHistoryLimit dictates how the package controller cleans up old\ninactive package revisions.\nDefaults to 1. Can be disabled by explicitly setting to 0.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "runtimeConfigRef": {
+          "default": {
+            "name": "default"
+          },
+          "description": "RuntimeConfigRef references a RuntimeConfig resource that will be used\nto configure the package runtime.",
+          "properties": {
+            "apiVersion": {
+              "default": "pkg.crossplane.io/v1beta1",
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "kind": {
+              "default": "DeploymentRuntimeConfig",
+              "description": "Kind of the referent.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the RuntimeConfig.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "skipDependencyResolution": {
+          "default": false,
+          "description": "SkipDependencyResolution indicates to the package manager whether to skip\nresolving dependencies for a package. Setting this value to true may have\nunintended consequences.\nDefault is false.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "package"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "FunctionStatus represents the observed state of a Function.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions of the resource.",
+          "items": {
+            "description": "A Condition that may apply to a resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time this condition transitioned from one\nstatus to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A Message containing details about this condition's last transition from\none status to another, if any.",
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "reason": {
+                "description": "A Reason for this condition's last transition from one status to another.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of this condition; is it currently True, False, or Unknown?",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of this condition. At most one of each condition type may apply to\na resource at any point in time.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "currentIdentifier": {
+          "description": "CurrentIdentifier is the most recent package source that was used to\nproduce a revision. The package manager uses this field to determine\nwhether to check for package updates for a given source when\npackagePullPolicy is set to IfNotPresent. Manually removing this field\nwill cause the package manager to check that the current revision is\ncorrect for the given package source.",
+          "type": "string"
+        },
+        "currentRevision": {
+          "description": "CurrentRevision is the name of the current package revision. It will\nreflect the most up to date revision, whether it has been activated or\nnot.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}

--- a/master-standalone/argoworkflowresourcev2claim-deployment-v1alpha1.json
+++ b/master-standalone/argoworkflowresourcev2claim-deployment-v1alpha1.json
@@ -1,0 +1,61 @@
+{
+  "type": "object",
+  "properties": {
+    "spec": {
+      "type": "object",
+      "properties": {
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "serviceAccountNamespace": {
+              "type": "string",
+              "description": "Kubernetes namespace of the service account."
+            },
+            "bucketArn": {
+              "type": "string",
+              "description": "ARN of the S3 bucket for storing artifacts."
+            },
+            "oidcProvider": {
+              "type": "object",
+              "properties": {
+                "arn": {
+                  "type": "string",
+                  "description": "ARN of the OIDC provider."
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Name of the OIDC provider."
+                }
+              },
+              "required": [
+                "arn",
+                "name"
+              ],
+              "additionalProperties": false
+            }
+          },
+          "required": [
+            "serviceAccountNamespace",
+            "bucketArn",
+            "oidcProvider"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "parameters"
+      ],
+      "additionalProperties": false
+    },
+    "status": {
+      "type": "object",
+      "properties": {
+        "roleArn": {
+          "type": "string",
+          "description": "ARN of the created IAM Role."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/master-standalone/function-pkg-v1.json
+++ b/master-standalone/function-pkg-v1.json
@@ -1,0 +1,183 @@
+{
+  "description": "A Function installs an OCI compatible Crossplane package, extending\nCrossplane with support for a new kind of composition function.\n\n\nRead the Crossplane documentation for\n[more information about Functions](https://docs.crossplane.io/latest/concepts/composition-functions).",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object"
+    },
+    "spec": {
+      "description": "FunctionSpec specifies the configuration of a Function.",
+      "properties": {
+        "commonLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand services.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/",
+          "type": "object"
+        },
+        "controllerConfigRef": {
+          "description": "ControllerConfigRef references a ControllerConfig resource that will be\nused to configure the packaged controller Deployment.\nDeprecated: Use RuntimeConfigReference instead.",
+          "properties": {
+            "name": {
+              "description": "Name of the ControllerConfig.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "ignoreCrossplaneConstraints": {
+          "default": false,
+          "description": "IgnoreCrossplaneConstraints indicates to the package manager whether to\nhonor Crossplane version constrains specified by the package.\nDefault is false.",
+          "type": "boolean"
+        },
+        "package": {
+          "description": "Package is the name of the package that is being requested.",
+          "type": "string"
+        },
+        "packagePullPolicy": {
+          "default": "IfNotPresent",
+          "description": "PackagePullPolicy defines the pull policy for the package.\nDefault is IfNotPresent.",
+          "type": "string"
+        },
+        "packagePullSecrets": {
+          "description": "PackagePullSecrets are named secrets in the same namespace that can be used\nto fetch packages from private registries.",
+          "items": {
+            "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+            "properties": {
+              "name": {
+                "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                "type": "string"
+              }
+            },
+            "type": "object",
+            "x-kubernetes-map-type": "atomic",
+            "additionalProperties": false
+          },
+          "type": "array"
+        },
+        "revisionActivationPolicy": {
+          "default": "Automatic",
+          "description": "RevisionActivationPolicy specifies how the package controller should\nupdate from one revision to the next. Options are Automatic or Manual.\nDefault is Automatic.",
+          "type": "string"
+        },
+        "revisionHistoryLimit": {
+          "default": 1,
+          "description": "RevisionHistoryLimit dictates how the package controller cleans up old\ninactive package revisions.\nDefaults to 1. Can be disabled by explicitly setting to 0.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "runtimeConfigRef": {
+          "default": {
+            "name": "default"
+          },
+          "description": "RuntimeConfigRef references a RuntimeConfig resource that will be used\nto configure the package runtime.",
+          "properties": {
+            "apiVersion": {
+              "default": "pkg.crossplane.io/v1beta1",
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "kind": {
+              "default": "DeploymentRuntimeConfig",
+              "description": "Kind of the referent.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the RuntimeConfig.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object",
+          "additionalProperties": false
+        },
+        "skipDependencyResolution": {
+          "default": false,
+          "description": "SkipDependencyResolution indicates to the package manager whether to skip\nresolving dependencies for a package. Setting this value to true may have\nunintended consequences.\nDefault is false.",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "package"
+      ],
+      "type": "object",
+      "additionalProperties": false
+    },
+    "status": {
+      "description": "FunctionStatus represents the observed state of a Function.",
+      "properties": {
+        "conditions": {
+          "description": "Conditions of the resource.",
+          "items": {
+            "description": "A Condition that may apply to a resource.",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time this condition transitioned from one\nstatus to another.",
+                "format": "date-time",
+                "type": "string"
+              },
+              "message": {
+                "description": "A Message containing details about this condition's last transition from\none status to another, if any.",
+                "type": "string"
+              },
+              "observedGeneration": {
+                "description": "ObservedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "format": "int64",
+                "type": "integer"
+              },
+              "reason": {
+                "description": "A Reason for this condition's last transition from one status to another.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of this condition; is it currently True, False, or Unknown?",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of this condition. At most one of each condition type may apply to\na resource at any point in time.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "lastTransitionTime",
+              "reason",
+              "status",
+              "type"
+            ],
+            "type": "object",
+            "additionalProperties": false
+          },
+          "type": "array",
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "currentIdentifier": {
+          "description": "CurrentIdentifier is the most recent package source that was used to\nproduce a revision. The package manager uses this field to determine\nwhether to check for package updates for a given source when\npackagePullPolicy is set to IfNotPresent. Manually removing this field\nwill cause the package manager to check that the current revision is\ncorrect for the given package source.",
+          "type": "string"
+        },
+        "currentRevision": {
+          "description": "CurrentRevision is the name of the current package revision. It will\nreflect the most up to date revision, whether it has been activated or\nnot.",
+          "type": "string"
+        }
+      },
+      "type": "object",
+      "additionalProperties": false
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
https://jira.mongodb.org/browse/SRE-17602

ctx: https://mongodb.slack.com/archives/C2TANV1LP/p1783340227738099
related: https://github.com/xgen-cloud/kube-resources/pull/11541


Sources
* Function `pkg.crossplane.io/v1`
  * from Crossplane  v1.17.3
  * matches  universal-crossplane  chart pin in  xgen-cloud/kube-resources 
* ArgoWorkflowResourceV2Claim deployment.10gen.cc/v1alpha1
  * from local XRD: https://github.com/xgen-cloud/kube-resources/blob/master/apps/base/argo-workflows/resources/crossplane-v2.yaml
